### PR TITLE
Handle null baseDirs in ErrorMessageParser (#54)

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestResults/ErrorMessageParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/ErrorMessageParserTests.cs
@@ -66,6 +66,20 @@ namespace GoogleTestAdapter.TestResults
             parser.ErrorStackTrace.Should().Contain($"#2 - {DummyExecutable}:42");
         }
 
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void Parse_NullBaseDir()
+        {
+            string errorString = $"{FullPathOfDummyExecutable}:37: error: Expected: Yes\nActual: Maybe";
+            errorString += $"\n{FullPathOfDummyExecutable}:42: Failure\nExpected: Foo\nActual: Bar";
+
+            var parser = new ErrorMessageParser(errorString, null);
+            parser.Parse();
+
+            parser.ErrorMessage.Should().Be("#1 - Expected: Yes\nActual: Maybe\n#2 - Expected: Foo\nActual: Bar");
+            parser.ErrorStackTrace.Should().Contain($"#1 - {DummyExecutable}:37");
+            parser.ErrorStackTrace.Should().Contain($"#2 - {DummyExecutable}:42");
+        }
     }
 
 }

--- a/GoogleTestAdapter/Core/TestResults/ErrorMessageParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/ErrorMessageParser.cs
@@ -41,7 +41,7 @@ namespace GoogleTestAdapter.TestResults
 
         private ErrorMessageParser(string baseDir)
         {
-            string escapedBaseDir = Regex.Escape(baseDir);
+            string escapedBaseDir = Regex.Escape(baseDir ?? "");
             string file = $"({escapedBaseDir}{ValidCharRegex}*)";
             string line = "([0-9]+)";
             string fileAndLine = $@"{file}((:{line})|(\({line}\):))";


### PR DESCRIPTION
- Add test argument of ErrorMessageParser ctor
- Add a unit test

+ take into account remark from @csoltenborn 