### PR TITLE
Make GTA_Traits work with googletest > 1.8.0

### DIFF
--- a/GoogleTestAdapter/Core/Resources/GTA_Traits.h
+++ b/GoogleTestAdapter/Core/Resources/GTA_Traits.h
@@ -116,6 +116,7 @@ class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public parent_class {\
   ::test_info_ =\
     ::testing::internal::MakeAndRegisterTestInfo(\
         #test_case_name, #test_name, NULL, NULL, \
+        ::testing::internal::CodeLocation(__FILE__, __LINE__), \
         (parent_id), \
         parent_class::SetUpTestCase, \
         parent_class::TearDownTestCase, \


### PR DESCRIPTION
The signature of `MakeAndRegisterTestInfo` changed and needs to be adjusted.