### PR TITLE
reusing test case information to speed up execution of selected tests (#107)

### DIFF
--- a/GoogleTestAdapter/Core.Tests/GoogleTestExecutorTests.cs
+++ b/GoogleTestAdapter/Core.Tests/GoogleTestExecutorTests.cs
@@ -44,7 +44,7 @@ namespace GoogleTestAdapter
 
             var collectingReporter = new FakeFrameworkReporter();
             var testExecutor = new GoogleTestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
-            testExecutor.RunTests(TestDataCreator.AllTestCasesExceptLoadTests, TestDataCreator.AllTestCasesExceptLoadTests, collectingReporter, null, false, TestResources.SampleTestsSolutionDir, processExecutor);
+            testExecutor.RunTests(TestDataCreator.AllTestCasesExceptLoadTests, collectingReporter, null, false, TestResources.SampleTestsSolutionDir, processExecutor);
 
             sampleTestsDurationsFile.AsFileInfo()
                 .Should()

--- a/GoogleTestAdapter/Core.Tests/Runners/CommandLineGeneratorTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Runners/CommandLineGeneratorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using GoogleTestAdapter.Helpers;
 using GoogleTestAdapter.Settings;
 using GoogleTestAdapter.Tests.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,7 +26,7 @@ namespace GoogleTestAdapter.Runners
             Action a =
                 () =>
                     // ReSharper disable once ObjectCreationAsStatement
-                    new CommandLineGenerator(new List<Model.TestCase>(), new List<Model.TestCase>(), 0, null, "",
+                    new CommandLineGenerator(new List<Model.TestCase>(), 0, null, "",
                         TestEnvironment.Options);
             a.ShouldThrow<ArgumentNullException>();
         }
@@ -36,7 +37,7 @@ namespace GoogleTestAdapter.Runners
         {
             string userParameters = "-testdirectory=\"MyTestDirectory\"";
 
-            string commandLine = new CommandLineGenerator(new List<Model.TestCase>(), new List<Model.TestCase>(), TestDataCreator.DummyExecutable.Length, userParameters, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(new List<Model.TestCase>(), TestDataCreator.DummyExecutable.Length, userParameters, "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().EndWith(" -testdirectory=\"MyTestDirectory\"");
         }
@@ -46,7 +47,7 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_AllTests_ProducesCorrectArguments()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1 param", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}");
         }
@@ -56,13 +57,13 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_CatchExceptionsOption_IsAppendedCorrectly()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             string catchExceptionsOption = GoogleTestConstants.GetCatchExceptionsOption(true);
             commandLine.Should().Contain(catchExceptionsOption);
 
             MockOptions.Setup(o => o.CatchExceptions).Returns(false);
 
-            commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             catchExceptionsOption = GoogleTestConstants.GetCatchExceptionsOption(false);
 
             commandLine.Should().Contain(catchExceptionsOption);
@@ -73,13 +74,13 @@ namespace GoogleTestAdapter.Runners
         public void GetCommandLines_BreakOnFailureOption_IsAppendedCorrectly()
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             string breakOnFailureOption = GoogleTestConstants.GetBreakOnFailureOption(false);
             commandLine.Should().Contain(breakOnFailureOption);
 
             MockOptions.Setup(o => o.BreakOnFailure).Returns(true);
 
-            commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
             breakOnFailureOption = GoogleTestConstants.GetBreakOnFailureOption(true);
             commandLine.Should().Contain(breakOnFailureOption);
         }
@@ -91,7 +92,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.NrOfTestRepetitions).Returns(4711);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             string repetitionsOption = GoogleTestConstants.NrOfRepetitionsOption + "=4711";
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}{repetitionsOption}");
@@ -104,7 +105,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.ShuffleTests).Returns(true);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs}{GoogleTestConstants.ShuffleTestsOption}");
         }
@@ -117,7 +118,7 @@ namespace GoogleTestAdapter.Runners
             MockOptions.Setup(o => o.ShuffleTestsSeed).Returns(4711);
 
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("Suite1.Test1", "Suite2.Test2");
-            string commandLine = new CommandLineGenerator(testCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
+            string commandLine = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options).GetCommandLines().First().CommandLine;
 
             string shuffleTestsOption = GoogleTestConstants.ShuffleTestsOption
                 + GoogleTestConstants.ShuffleTestsSeedOption + "=4711";
@@ -128,10 +129,11 @@ namespace GoogleTestAdapter.Runners
         [TestCategory(Unit)]
         public void GetCommandLines_TestsWithCommonSuite_AreCombinedViaSuite()
         {
-            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCases("FooSuite.BarTest", "FooSuite.BazTest");
-            IEnumerable<Model.TestCase> allTestCases = testCasesWithCommonSuite.Union(TestDataCreator.CreateDummyTestCases("BarSuite.FooTest"));
+            string[] testCaseNamesWithCommonSuite = { "FooSuite.BarTest", "FooSuite.BazTest" };
+            string[] allTestCaseNames = testCaseNamesWithCommonSuite.Union("BarSuite.FooTest".Yield()).ToArray();
+            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithCommonSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(allTestCases, testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should().Be($"--gtest_output=\"xml:\"{DefaultArgs} --gtest_filter=FooSuite.*:");
@@ -141,13 +143,18 @@ namespace GoogleTestAdapter.Runners
         [TestCategory(Unit)]
         public void GetCommandLines_ParameterizedTestsWithCommonSuite_AreCombinedViaSuite()
         {
-            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCases(
+            string[] testCaseNamesWithCommonSuite =
+            {
                 "InstantiationName2/ParameterizedTests.SimpleTraits/0",
                 "InstantiationName/ParameterizedTests.SimpleTraits/0",
-                "InstantiationName/ParameterizedTests.SimpleTraits/1");
-            IEnumerable<Model.TestCase> allTestCases = testCasesWithCommonSuite.Union(TestDataCreator.CreateDummyTestCases("InstantiationName2/ParameterizedTests.SimpleTraits/1  # GetParam() = (,2)"));
+                "InstantiationName/ParameterizedTests.SimpleTraits/1"
+            };
+            string[] allTestCaseNames = testCaseNamesWithCommonSuite
+                .Union("InstantiationName2/ParameterizedTests.SimpleTraits/1  # GetParam() = (,2)".Yield())
+                .ToArray();
+            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithCommonSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(allTestCases, testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -159,14 +166,16 @@ namespace GoogleTestAdapter.Runners
         [TestCategory(Unit)]
         public void GetCommandLines_TestsWithCommonSuiteInReverseOrder_AreCombinedViaSuite()
         {
-            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCases("FooSuite.BarTest", "FooSuite.BazTest",
-                "FooSuite.gsdfgdfgsdfg", "FooSuite.23453452345", "FooSuite.bxcvbxcvbxcvb");
-            IEnumerable<Model.TestCase> allTestCases = testCasesWithCommonSuite.Union(TestDataCreator.CreateDummyTestCases("BarSuite.BarTest"));
+            string[] testCaseNamesWithCommonSuite = { "FooSuite.BarTest", "FooSuite.BazTest",
+                "FooSuite.gsdfgdfgsdfg", "FooSuite.23453452345", "FooSuite.bxcvbxcvbxcvb" };
+            string[] allTestCaseNames = testCaseNamesWithCommonSuite.Union("BarSuite.BarTest".Yield()).ToArray();
+            IEnumerable<Model.TestCase> testCasesWithCommonSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithCommonSuite, allTestCaseNames);
+
             IEnumerable<Model.TestCase> testCasesReversed = testCasesWithCommonSuite.Reverse();
 
-            string commandLine = new CommandLineGenerator(allTestCases, testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithCommonSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
-            string commandLineFromBackwards = new CommandLineGenerator(allTestCases, testCasesReversed, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLineFromBackwards = new CommandLineGenerator(testCasesReversed, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             string expectedCommandLine = $"--gtest_output=\"xml:\"{DefaultArgs} --gtest_filter=FooSuite.*:";
@@ -178,10 +187,11 @@ namespace GoogleTestAdapter.Runners
         [TestCategory(Unit)]
         public void GetCommandLines_TestsWithoutCommonSuite_AreNotCombined()
         {
-            IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCases("FooSuite.BarTest", "BarSuite.BazTest1");
-            IEnumerable<Model.TestCase> allTestCases = testCasesWithDifferentSuite.Union(TestDataCreator.CreateDummyTestCases("FooSuite.BazTest", "BarSuite.BazTest2"));
+            string[] testCaseNamesWithDifferentSuite = { "FooSuite.BarTest", "BarSuite.BazTest1" };
+            string[] allTestCaseNames = testCaseNamesWithDifferentSuite.Union(new[]{ "FooSuite.BazTest", "BarSuite.BazTest2" }).ToArray();
+            IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithDifferentSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(allTestCases, testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -192,10 +202,11 @@ namespace GoogleTestAdapter.Runners
         [TestCategory(Unit)]
         public void GetCommandLines_TestsWithoutCommonSuiteInDifferentOrder_AreNotCombined()
         {
-            IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCases("BarSuite.BazTest1", "FooSuite.BarTest");
-            IEnumerable<Model.TestCase> allTestCases = testCasesWithDifferentSuite.Union(TestDataCreator.CreateDummyTestCases("FooSuite.BazTest", "BarSuite.BazTest2"));
+            string[] testCaseNamesWithDifferentSuite = { "BarSuite.BazTest1", "FooSuite.BarTest" };
+            string[] allTestCaseNames = testCaseNamesWithDifferentSuite.Union(new[] { "FooSuite.BazTest", "BarSuite.BazTest2" }).ToArray();
+            IEnumerable<Model.TestCase> testCasesWithDifferentSuite = TestDataCreator.CreateDummyTestCasesFull(testCaseNamesWithDifferentSuite, allTestCaseNames);
 
-            string commandLine = new CommandLineGenerator(allTestCases, testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            string commandLine = new CommandLineGenerator(testCasesWithDifferentSuite, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().First().CommandLine;
 
             commandLine.Should()
@@ -210,14 +221,16 @@ namespace GoogleTestAdapter.Runners
             List<string> testsToExecute = new List<string>();
             for (int i = 0; i < 1000; i++)
             {
-                allTests.Add("MyTestSuite" + i + ".MyTest");
-                testsToExecute.Add("MyTestSuite" + i + ".MyTest");
-                allTests.Add("MyTestSuite" + i + ".MyTest2");
-            }
-            IEnumerable<Model.TestCase> allTestCases = allTests.Select(TestDataCreator.ToTestCase).ToList();
-            IEnumerable<Model.TestCase> testCases = testsToExecute.Select(TestDataCreator.ToTestCase).ToList();
+                string test1 = $"MyTestSuite{i}.MyTest";
+                string test2 = $"MyTestSuite{i}.MyTest2";
 
-            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(allTestCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+                allTests.Add(test1);
+                testsToExecute.Add(test1);
+                allTests.Add(test2);
+            }
+            IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCasesFull(testsToExecute.ToArray(), allTests.ToArray());
+
+            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().ToList();
 
             commands.Count.Should().Be(3);
@@ -262,10 +275,9 @@ namespace GoogleTestAdapter.Runners
             testsToExecute.Add("MyTestSuite1.MyTest2");
             testsToExecute.Add("MyTestSuite5.MyTest2");
 
-            IEnumerable<Model.TestCase> allTestCases = allTests.Select(TestDataCreator.ToTestCase).ToList();
-            IEnumerable<Model.TestCase> testCases = testsToExecute.Select(TestDataCreator.ToTestCase).ToList();
+            IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCasesFull(testsToExecute.ToArray(), allTests.ToArray());
 
-            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(allTestCases, testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
+            List<CommandLineGenerator.Args> commands = new CommandLineGenerator(testCases, TestDataCreator.DummyExecutable.Length, "", "", TestEnvironment.Options)
                 .GetCommandLines().ToList();
 
             commands.Count.Should().Be(3);

--- a/GoogleTestAdapter/Core.Tests/Runners/SequentialTestRunnerTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Runners/SequentialTestRunnerTests.cs
@@ -39,13 +39,12 @@ namespace GoogleTestAdapter.Runners
         private void DoRunCancelingTests(bool killProcesses, int lower, int upper)
         {
             MockOptions.Setup(o => o.KillProcessesOnCancel).Returns(killProcesses);
-            List<TestCase> allTestCases = TestDataCreator.AllTestCasesExceptLoadTests;
             List<TestCase> testCasesToRun = TestDataCreator.GetTestCases("Crashing.LongRunning", "LongRunningTests.Test2");
 
             var stopwatch = new Stopwatch();
             var runner = new SequentialTestRunner("", MockFrameworkReporter.Object, TestEnvironment.Logger, TestEnvironment.Options, new SchedulingAnalyzer(TestEnvironment.Logger));
             var executor = new ProcessExecutor(null, MockLogger.Object);
-            var thread = new Thread(() => runner.RunTests(allTestCases, testCasesToRun, "", "", "", false, null, executor));
+            var thread = new Thread(() => runner.RunTests(testCasesToRun, "", "", "", false, null, executor));
 
             stopwatch.Start();
             thread.Start();

--- a/GoogleTestAdapter/Core/Core.csproj
+++ b/GoogleTestAdapter/Core/Core.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Helpers\ProcessLauncher.cs" />
     <Compile Include="Helpers\TestProcessLauncher.cs" />
     <Compile Include="Helpers\RegexTraitParser.cs" />
+    <Compile Include="Model\TestCaseMetaDataProperty.cs" />
+    <Compile Include="Model\TestProperty.cs" />
     <Compile Include="Scheduling\SchedulingAnalyzer.cs" />
     <Compile Include="Settings\IGoogleTestAdapterSettingsContainer.cs" />
     <Compile Include="Settings\RunSettings.cs" />

--- a/GoogleTestAdapter/Core/GoogleTestExecutor.cs
+++ b/GoogleTestAdapter/Core/GoogleTestExecutor.cs
@@ -28,7 +28,7 @@ namespace GoogleTestAdapter
         }
 
 
-        public void RunTests(IEnumerable<TestCase> allTestCasesInExecutables, IEnumerable<TestCase> testCasesToRun, ITestFrameworkReporter reporter, IDebuggedProcessLauncher launcher, bool isBeingDebugged, string solutionDirectory, IProcessExecutor executor)
+        public void RunTests(IEnumerable<TestCase> testCasesToRun, ITestFrameworkReporter reporter, IDebuggedProcessLauncher launcher, bool isBeingDebugged, string solutionDirectory, IProcessExecutor executor)
         {
             TestCase[] testCasesToRunAsArray = testCasesToRun as TestCase[] ?? testCasesToRun.ToArray();
             _logger.LogInfo("Running " + testCasesToRunAsArray.Length + " tests...");
@@ -42,7 +42,7 @@ namespace GoogleTestAdapter
                 ComputeTestRunner(reporter, isBeingDebugged, solutionDirectory);
             }
 
-            _runner.RunTests(allTestCasesInExecutables, testCasesToRunAsArray, solutionDirectory, null, null, isBeingDebugged, launcher, executor);
+            _runner.RunTests(testCasesToRunAsArray, solutionDirectory, null, null, isBeingDebugged, launcher, executor);
 
             if (_settings.ParallelTestExecution)
                 _schedulingAnalyzer.PrintStatisticsToDebugOutput();

--- a/GoogleTestAdapter/Core/Model/TestCase.cs
+++ b/GoogleTestAdapter/Core/Model/TestCase.cs
@@ -13,6 +13,7 @@ namespace GoogleTestAdapter.Model
         public int LineNumber { get; }
 
         public List<Trait> Traits { get; } = new List<Trait>();
+        public List<TestProperty> Properties { get; } = new List<TestProperty>();
 
         public TestCase(string fullyQualifiedName, string source, string displayName, string codeFilePath, int lineNumber)
         {

--- a/GoogleTestAdapter/Core/Model/TestCaseMetaDataProperty.cs
+++ b/GoogleTestAdapter/Core/Model/TestCaseMetaDataProperty.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+
+namespace GoogleTestAdapter.Model
+{
+    public class TestCaseMetaDataProperty : TestProperty
+    {
+        public static readonly string Id = $"{typeof(TestCaseMetaDataProperty).FullName}";
+        public const string Label = "Test case meta data";
+
+        public int NrOfTestCasesInSuite { get; }
+        public int NrOfTestCasesInExecutable { get; }
+
+        public TestCaseMetaDataProperty(int nrOfTestCasesInSuite, int nrOfTestCasesInExecutable)
+            : this($"{nrOfTestCasesInSuite}:{nrOfTestCasesInExecutable}")
+        {
+        }
+
+        public TestCaseMetaDataProperty(string serialization) : base(serialization)
+        {
+            int[] values = serialization.Split(':').Select(int.Parse).ToArray();
+            if (values.Length != 2)
+                throw new ArgumentException(serialization, nameof(serialization));
+            NrOfTestCasesInSuite = values[0];
+            NrOfTestCasesInExecutable = values[1];
+        }
+    }
+}

--- a/GoogleTestAdapter/Core/Model/TestProperty.cs
+++ b/GoogleTestAdapter/Core/Model/TestProperty.cs
@@ -1,0 +1,35 @@
+﻿namespace GoogleTestAdapter.Model
+{
+    public abstract class TestProperty
+    {
+        public string Serialization { get; }
+
+        protected TestProperty(string serialization)
+        {
+            Serialization = serialization;
+        }
+
+        public override string ToString()
+        {
+            return $"{GetType()}: {Serialization}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+
+            var other = (TestProperty) obj;
+            return string.Equals(Serialization, other.Serialization);
+        }
+
+        public override int GetHashCode()
+        {
+            return Serialization != null ? Serialization.GetHashCode() : 0;
+        }
+    }
+}

--- a/GoogleTestAdapter/Core/Runners/ITestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/ITestRunner.cs
@@ -8,7 +8,7 @@ namespace GoogleTestAdapter.Runners
     public interface ITestRunner
     {
         // TODO remove isBeingDebugged parameter (use debuggedLauncher != null)
-        void RunTests(IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir, string workingDir,
+        void RunTests(IEnumerable<TestCase> testCasesToRun, string baseDir, string workingDir,
             string userParameters, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor);
 
         void Cancel();

--- a/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
@@ -30,7 +30,7 @@ namespace GoogleTestAdapter.Runners
         }
 
 
-        public void RunTests(IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir,
+        public void RunTests(IEnumerable<TestCase> testCasesToRun, string baseDir,
             string workingDir, string userParameters, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
             List<Thread> threads;
@@ -40,7 +40,7 @@ namespace GoogleTestAdapter.Runners
                 DebugUtils.AssertIsNull(userParameters, nameof(userParameters));
 
                 threads = new List<Thread>();
-                RunTests(allTestCases, testCasesToRun, baseDir, threads, isBeingDebugged, debuggedLauncher, executor);
+                RunTests(testCasesToRun, baseDir, threads, isBeingDebugged, debuggedLauncher, executor);
             }
 
             foreach (Thread thread in threads)
@@ -61,7 +61,7 @@ namespace GoogleTestAdapter.Runners
         }
 
 
-        private void RunTests(IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir, List<Thread> threads, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
+        private void RunTests(IEnumerable<TestCase> testCasesToRun, string baseDir, List<Thread> threads, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
             TestCase[] testCasesToRunAsArray = testCasesToRun as TestCase[] ?? testCasesToRun.ToArray();
 
@@ -78,7 +78,7 @@ namespace GoogleTestAdapter.Runners
                 _testRunners.Add(runner);
 
                 var thread = new Thread(
-                    () => runner.RunTests(allTestCases, testcases, baseDir, null, null, isBeingDebugged, debuggedLauncher, executor)){ Name = $"GTA Testrunner {threadId}" };
+                    () => runner.RunTests(testcases, baseDir, null, null, isBeingDebugged, debuggedLauncher, executor)){ Name = $"GTA Testrunner {threadId}" };
                 threads.Add(thread);
 
                 thread.Start();

--- a/GoogleTestAdapter/Core/Runners/PreparingTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/PreparingTestRunner.cs
@@ -41,7 +41,7 @@ namespace GoogleTestAdapter.Runners
         }
 
 
-        public void RunTests(IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir,
+        public void RunTests(IEnumerable<TestCase> testCasesToRun, string baseDir,
              string workingDir, string userParameters, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
             DebugUtils.AssertIsNull(userParameters, nameof(userParameters));
@@ -59,7 +59,7 @@ namespace GoogleTestAdapter.Runners
                 batch = batch == "" ? "" : _solutionDirectory + batch;
                 SafeRunBatch(TestSetup, _solutionDirectory, batch, isBeingDebugged);
 
-                _innerTestRunner.RunTests(allTestCases, testCasesToRun, baseDir, workingDir, userParameters, isBeingDebugged, debuggedLauncher, executor);
+                _innerTestRunner.RunTests(testCasesToRun, baseDir, workingDir, userParameters, isBeingDebugged, debuggedLauncher, executor);
 
                 batch = _settings.GetBatchForTestTeardown(_solutionDirectory, testDirectory, _threadId);
                 batch = batch == "" ? "" : _solutionDirectory + batch;

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -34,14 +34,13 @@ namespace GoogleTestAdapter.Runners
         }
 
 
-        public void RunTests(IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir,
+        public void RunTests(IEnumerable<TestCase> testCasesToRun, string baseDir,
             string workingDir, string userParameters, bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
             DebugUtils.AssertIsNotNull(userParameters, nameof(userParameters));
             DebugUtils.AssertIsNotNull(workingDir, nameof(workingDir));
 
             IDictionary<string, List<TestCase>> groupedTestCases = testCasesToRun.GroupByExecutable();
-            TestCase[] allTestCasesAsArray = allTestCases as TestCase[] ?? allTestCases.ToArray();
             foreach (string executable in groupedTestCases.Keys)
             {
                 string finalParameters = SettingsWrapper.ReplacePlaceholders(userParameters, executable);
@@ -55,9 +54,7 @@ namespace GoogleTestAdapter.Runners
                     RunTestsFromExecutable(
                         executable,
                         finalWorkingDir,
-                        allTestCasesAsArray.Where(tc => tc.Source == executable),
                         groupedTestCases[executable],
-                        baseDir,
                         finalParameters,
                         isBeingDebugged,
                         debuggedLauncher,
@@ -80,13 +77,13 @@ namespace GoogleTestAdapter.Runners
 
         // ReSharper disable once UnusedParameter.Local
         private void RunTestsFromExecutable(string executable, string workingDir,
-            IEnumerable<TestCase> allTestCases, IEnumerable<TestCase> testCasesToRun, string baseDir, string userParameters,
+            IEnumerable<TestCase> testCasesToRun, string userParameters,
             bool isBeingDebugged, IDebuggedProcessLauncher debuggedLauncher, IProcessExecutor executor)
         {
             string resultXmlFile = Path.GetTempFileName();
             var serializer = new TestDurationSerializer();
 
-            var generator = new CommandLineGenerator(allTestCases, testCasesToRun, executable.Length, userParameters, resultXmlFile, _settings);
+            var generator = new CommandLineGenerator(testCasesToRun, executable.Length, userParameters, resultXmlFile, _settings);
             foreach (CommandLineGenerator.Args arguments in generator.GetCommandLines())
             {
                 if (_canceled)

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -9,7 +9,6 @@ using GoogleTestAdapter.Framework;
 using GoogleTestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using GoogleTestAdapter.Helpers;
 using GoogleTestAdapter.Settings;
 using GoogleTestAdapter.Model;
 using GoogleTestAdapter.TestAdapter.Helpers;
@@ -97,7 +96,7 @@ namespace GoogleTestAdapter.TestAdapter
                 allTestCasesInExecutables.Where(
                     tc => vsTestCasesToRun.Any(vtc => tc.FullyQualifiedName == vtc.FullyQualifiedName)).ToArray();
 
-            DoRunTests(allTestCasesInExecutables, testCasesToRun, runContext, frameworkHandle);
+            DoRunTests(testCasesToRun, runContext, frameworkHandle);
 
             stopwatch.Stop();
             _logger.LogInfo($"Google Test execution completed, overall duration: {stopwatch.Elapsed}.");
@@ -112,11 +111,8 @@ namespace GoogleTestAdapter.TestAdapter
             var filter = new TestCaseFilter(runContext, allTraitNames, _logger);
             vsTestCasesToRun = filter.Filter(vsTestCasesToRunAsArray);
 
-            IEnumerable<TestCase> allTestCasesInExecutables =
-                GetAllTestCasesInExecutables(vsTestCasesToRun.Select(tc => tc.Source).Distinct());
-
             ICollection<TestCase> testCasesToRun = vsTestCasesToRun.Select(tc => tc.ToTestCase()).ToArray();
-            DoRunTests(allTestCasesInExecutables, testCasesToRun, runContext, frameworkHandle);
+            DoRunTests(testCasesToRun, runContext, frameworkHandle);
 
             stopwatch.Stop();
             _logger.LogInfo($"Google Test execution completed, overall duration: {stopwatch.Elapsed}.");
@@ -183,9 +179,7 @@ namespace GoogleTestAdapter.TestAdapter
             return allTraitNames;
         }
 
-        private void DoRunTests(
-            IEnumerable<TestCase> allTestCasesInExecutables, ICollection<TestCase> testCasesToRun,
-            IRunContext runContext, IFrameworkHandle frameworkHandle)
+        private void DoRunTests(ICollection<TestCase> testCasesToRun, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             bool isRunningInsideVisualStudio = !string.IsNullOrEmpty(runContext.SolutionDirectory);
             var reporter = new VsTestFrameworkReporter(frameworkHandle, isRunningInsideVisualStudio, _logger);
@@ -205,7 +199,7 @@ namespace GoogleTestAdapter.TestAdapter
 
                 _executor = new GoogleTestExecutor(_logger, _settings);
             }
-            _executor.RunTests(allTestCasesInExecutables, testCasesToRun, reporter, launcher,
+            _executor.RunTests(testCasesToRun, reporter, launcher,
                 runContext.IsBeingDebugged, runContext.SolutionDirectory, processExecutor);
             reporter.AllTestsFinished();
         }


### PR DESCRIPTION
Reuse test cases provided by VS to speed up test execution of selected tests (i.e., if `ITestExecutor.RunTests(IEnumerable<VsTestCase> vsTestCasesToRun, IRunContext runContext, IFrameworkHandle frameworkHandle)` is invoked).

Test case meta information (# of tests in suite of test case, # of tests in executable of test case) is stored as TestProperties and used at test execution time to create test case selection parameters for Google Test (before, information about all available test cases was needed for this).