### PR TITLE
added regex pattern match logic for parent process traversal

### DIFF
--- a/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
+++ b/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using GoogleTestAdapter.Common;
 using GoogleTestAdapter.TestAdapter.Helpers;
 using Process = System.Diagnostics.Process;
@@ -41,6 +42,9 @@ namespace GoogleTestAdapter.TestAdapter.Framework
 
     public static class VsVersionUtils
     {
+        private const string parentProcessPattern = @"(^vstest\..*\.exe$)|(^devenv\.exe$)";
+        private static readonly Regex parentProcessRegex = new Regex(parentProcessPattern, RegexOptions.IgnoreCase);
+
         private static readonly Version LastUnsupportedVersion = new Version(11, 0, 50727, 1); // VS2012 without updates
 
         public static readonly VsVersion FirstSupportedVersion = VsVersion.VS2012_1;
@@ -96,7 +100,7 @@ namespace GoogleTestAdapter.TestAdapter.Framework
         {
             var process = Process.GetCurrentProcess();
             string executable = Path.GetFileName(process.MainModule.FileName).Trim().ToLower();
-            while (executable != null && executable != "devenv.exe" && executable != "vstest.console.exe")
+            while (executable != null && !parentProcessRegex.IsMatch(executable))
             {
                 process = ParentProcessUtils.GetParentProcess(process.Id);
                 executable = process != null 

--- a/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
+++ b/GoogleTestAdapter/TestAdapter/Framework/VsVersion.cs
@@ -42,8 +42,8 @@ namespace GoogleTestAdapter.TestAdapter.Framework
 
     public static class VsVersionUtils
     {
-        private const string parentProcessPattern = @"(^vstest\..*\.exe$)|(^devenv\.exe$)";
-        private static readonly Regex parentProcessRegex = new Regex(parentProcessPattern, RegexOptions.IgnoreCase);
+        private const string ParentProcessPattern = @"(^vstest\.((discoveryengine)|(executionengine)|(console)).*\.exe$)|(^devenv\.exe$)";
+        private static readonly Regex ParentProcessRegex = new Regex(ParentProcessPattern, RegexOptions.IgnoreCase);
 
         private static readonly Version LastUnsupportedVersion = new Version(11, 0, 50727, 1); // VS2012 without updates
 
@@ -100,7 +100,7 @@ namespace GoogleTestAdapter.TestAdapter.Framework
         {
             var process = Process.GetCurrentProcess();
             string executable = Path.GetFileName(process.MainModule.FileName).Trim().ToLower();
-            while (executable != null && !parentProcessRegex.IsMatch(executable))
+            while (executable != null && !ParentProcessRegex.IsMatch(executable))
             {
                 process = ParentProcessUtils.GetParentProcess(process.Id);
                 executable = process != null 


### PR DESCRIPTION
On our build server tests were executed by "vstest.executionengine.exe" instead of "vstest.console.exe".
Since there were multiple variants of "vstest.*.exe" I have added a regex match logic instead of direct equality check during the parent process traversal for visualstudio version control.

Note: The regex match is not perfect such as "vstest.SomeDummyName.exe" is accepted too.