### PR TITLE
bugfix: WorkingDir returned placeholder if setting was empty (but not null)

### DIFF
--- a/GoogleTestAdapter/Core.Tests/Settings/SettingsWrapperTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Settings/SettingsWrapperTests.cs
@@ -364,6 +364,58 @@ namespace GoogleTestAdapter.Settings
 
         [TestMethod]
         [TestCategory(Unit)]
+        public void GetWorkingDirForExecution_null_ExecutableDirIsReturned()
+        {
+            MockXmlOptions.Setup(o => o.WorkingDir).Returns((string)null);
+
+            var result = TheOptions.GetWorkingDirForExecution(TestResources.Tests_DebugX86, "", 0);
+
+            var expectedDir = new FileInfo(TestResources.Tests_DebugX86).Directory?.FullName;
+            result.Should().NotBeNullOrEmpty();
+            result.Should().BeEquivalentTo(expectedDir);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetWorkingDirForExecution_EmptyString_ExecutableDirIsReturned()
+        {
+            MockXmlOptions.Setup(o => o.WorkingDir).Returns("");
+
+            var result = TheOptions.GetWorkingDirForExecution(TestResources.Tests_DebugX86, "", 0);
+
+            var expectedDir = new FileInfo(TestResources.Tests_DebugX86).Directory?.FullName;
+            result.Should().NotBeNullOrEmpty();
+            result.Should().BeEquivalentTo(expectedDir);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetWorkingDirForDiscovery_null_ExecutableDirIsReturned()
+        {
+            MockXmlOptions.Setup(o => o.WorkingDir).Returns((string) null);
+
+            var result = TheOptions.GetWorkingDirForDiscovery(TestResources.Tests_DebugX86);
+
+            var expectedDir = new FileInfo(TestResources.Tests_DebugX86).Directory?.FullName;
+            result.Should().NotBeNullOrEmpty();
+            result.Should().BeEquivalentTo(expectedDir);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetWorkingDirForDiscovery_EmptyString_ExecutableDirIsReturned()
+        {
+            MockXmlOptions.Setup(o => o.WorkingDir).Returns("");
+
+            var result = TheOptions.GetWorkingDirForDiscovery(TestResources.Tests_DebugX86);
+
+            var expectedDir = new FileInfo(TestResources.Tests_DebugX86).Directory?.FullName;
+            result.Should().NotBeNullOrEmpty();
+            result.Should().BeEquivalentTo(expectedDir);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
         public void GetUserParams__EnvVarPlaceholderIsReplaced()
         {
             foreach (DictionaryEntry variable in Environment.GetEnvironmentVariables())

--- a/GoogleTestAdapter/Core/Settings/SettingsWrapper.cs
+++ b/GoogleTestAdapter/Core/Settings/SettingsWrapper.cs
@@ -335,13 +335,13 @@ namespace GoogleTestAdapter.Settings
             DescriptionOfThreadIdPlaceholder + DescriptionTestExecutionOnly + "\n" + 
             DescriptionOfEnvVarPlaceholders;
 
-        public virtual string WorkingDir => _currentSettings.WorkingDir ?? OptionWorkingDirDefaultValue;
+        public virtual string WorkingDir => string.IsNullOrWhiteSpace(_currentSettings.WorkingDir) 
+            ? OptionWorkingDirDefaultValue 
+            : _currentSettings.WorkingDir;
 
         public string GetWorkingDirForExecution(string executable, string testDirectory, int threadId)
         {
-            return string.IsNullOrWhiteSpace(WorkingDir) 
-                ? OptionWorkingDirDefaultValue 
-                : ReplaceEnvironmentVariables(
+            return ReplaceEnvironmentVariables(
                     ReplaceSolutionDirPlaceholder(
                         ReplaceExecutablePlaceholders(
                             ReplaceTestDirAndThreadIdPlaceholders(WorkingDir, testDirectory, threadId), executable)));
@@ -349,9 +349,7 @@ namespace GoogleTestAdapter.Settings
 
         public string GetWorkingDirForDiscovery(string executable)
         {
-            return string.IsNullOrWhiteSpace(WorkingDir) 
-                ? new FileInfo(executable).DirectoryName 
-                : ReplaceEnvironmentVariables(
+            return ReplaceEnvironmentVariables(
                     ReplaceSolutionDirPlaceholder(
                         RemoveTestDirAndThreadIdPlaceholders(
                             ReplaceExecutablePlaceholders(WorkingDir, executable))));


### PR DESCRIPTION
fix for #225 