### PR TITLE
Fix bug where a "my_class const" type would be shown as "my_const".

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestCases/ListTestsParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestCases/ListTestsParserTests.cs
@@ -79,9 +79,10 @@ namespace GoogleTestAdapter.TestCases
         [TestCategory(Unit)]
         public void ParseListTestsOutput_TestWithTypeParam_CorrectParsing()
         {
+            //NOTE: We also test that the keywords "class" and "struct" are correctly removed, without touching type names that would contain these words.
             var consoleOutput = new List<string>
             {
-                "TypedTests/0.  # TypeParam = class std::vector<int,class std::allocator<int> >",
+                "TypedTests/0.  # TypeParam = class std::tuple<struct my_struct const ,class gsl::span<class my_class const ,-1> >",
                 "  CanIterate",
             };
 
@@ -92,7 +93,7 @@ namespace GoogleTestAdapter.TestCases
             descriptors[0].Suite.Should().Be("TypedTests/0");
             descriptors[0].Name.Should().Be("CanIterate");
             descriptors[0].FullyQualifiedName.Should().Be("TypedTests/0.CanIterate");
-            descriptors[0].DisplayName.Should().Be("TypedTests/0.CanIterate<std::vector<int,std::allocator<int> > >");
+            descriptors[0].DisplayName.Should().Be("TypedTests/0.CanIterate<std::tuple<my_struct const ,gsl::span<my_class const ,-1> > >");
             descriptors[0].TestType.Should().Be(TestCaseDescriptor.TestTypes.TypeParameterized);
         }
 

--- a/GoogleTestAdapter/Core.Tests/TestCases/ListTestsParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestCases/ListTestsParserTests.cs
@@ -79,7 +79,28 @@ namespace GoogleTestAdapter.TestCases
         [TestCategory(Unit)]
         public void ParseListTestsOutput_TestWithTypeParam_CorrectParsing()
         {
-            //NOTE: We also test that the keywords "class" and "struct" are correctly removed, without touching type names that would contain these words.
+            var consoleOutput = new List<string>
+            {
+                "TypedTests/0.  # TypeParam = class std::vector<int,class std::allocator<int> >",
+                "  CanIterate",
+            };
+
+            IList<TestCaseDescriptor> descriptors = new ListTestsParser(TestEnvironment.Options.TestNameSeparator)
+                .ParseListTestsOutput(consoleOutput);
+
+            descriptors.Count.Should().Be(1);
+            descriptors[0].Suite.Should().Be("TypedTests/0");
+            descriptors[0].Name.Should().Be("CanIterate");
+            descriptors[0].FullyQualifiedName.Should().Be("TypedTests/0.CanIterate");
+            descriptors[0].DisplayName.Should().Be("TypedTests/0.CanIterate<std::vector<int,std::allocator<int> > >");
+            descriptors[0].TestType.Should().Be(TestCaseDescriptor.TestTypes.TypeParameterized);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void ParseListTestsOutput_TestWithTypeParam_DoesNotModifyName()
+        {
+            // We test that the keywords "class" and "struct" are correctly removed, without touching type names that would contain these words.
             var consoleOutput = new List<string>
             {
                 "TypedTests/0.  # TypeParam = class std::tuple<struct my_struct const ,class gsl::span<class my_class const ,-1> >",

--- a/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
+++ b/GoogleTestAdapter/Core/TestCases/StreamingListTestsParser.cs
@@ -10,6 +10,7 @@ namespace GoogleTestAdapter.TestCases
         private static readonly Regex NameRegex = new Regex($@"([\w\/]*)(?:{Regex.Escape(GoogleTestConstants.ParameterizedTestMarker)}(.*))?", RegexOptions.Compiled);
         private static readonly Regex IsParamRegex = new Regex(@"(\w+/)?\w+/\w+", RegexOptions.Compiled);
         private static readonly Regex IsParamRegexPreNamedParameters = new Regex(@"(\w+/)?\w+/\d+", RegexOptions.Compiled);
+        private static readonly Regex StructKeywordsRegex = new Regex(@"\b(?:class|struct) ", RegexOptions.Compiled);
 
         private readonly string _testNameSeparator;
 
@@ -47,9 +48,7 @@ namespace GoogleTestAdapter.TestCases
         {
             Match suiteMatch = SuiteRegex.Match(suiteLine);
             string suite = suiteMatch.Groups[1].Value;
-            string typeParam = suiteMatch.Groups[2].Value
-                .Replace("class ", "")
-                .Replace("struct ", "");
+            string typeParam = StructKeywordsRegex.Replace(suiteMatch.Groups[2].Value, "");
 
             Match nameMatch = NameRegex.Match(testCaseLine);
             string name = nameMatch.Groups[1].Value;


### PR DESCRIPTION
As my first pull request on this project, this is a small non critical bug fix.  When using type parameterized tests, if the type name ends with "class" or "struct" and is followed by a space (for example a "my_class const"), the type name was incorrectly modified in the DisplayName.  I changed the simple replace by a regex replace and modified the test to verify this case.