### PR TITLE
[WIP] Improve code coverage

### DIFF
--- a/GoogleTestAdapter/Common/DebuggerAttacherServiceConfiguration.cs
+++ b/GoogleTestAdapter/Common/DebuggerAttacherServiceConfiguration.cs
@@ -10,7 +10,7 @@ namespace GoogleTestAdapter.Common
     /// <summary>
     /// Helper class for DebuggerAttacherService.
     /// </summary>
-    public class DebuggerAttacherServiceConfiguration
+    public static class DebuggerAttacherServiceConfiguration
     {
         /// <summary>
         /// Relative address of the endpoint interface.
@@ -48,13 +48,6 @@ namespace GoogleTestAdapter.Common
             var endpointUri = new Uri(ConstructPipeUri(id), InterfaceAddress);
             var endpointAddress = new EndpointAddress(endpointUri);
             return ChannelFactory<IDebuggerAttacherService>.CreateChannel(binding, endpointAddress);
-        }
-
-        /// <summary>
-        /// Private default constructor to prevent from creating instances of this class.
-        /// </summary>
-        private DebuggerAttacherServiceConfiguration()
-        {
         }
     }
 }

--- a/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
+++ b/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
@@ -141,6 +141,7 @@ namespace GoogleTestAdapter
         }
 
         [TestMethod]
+        [TestCategory(Unit)]
         public void IsGoogleTestExecutable_WithSlowRegex_TimesOutAndProducesErrorMessage()
         {
             // regex from https://stackoverflow.com/questions/9687596/slow-regex-performance

--- a/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
+++ b/GoogleTestAdapter/Core.Tests/GoogleTestDiscovererTests.cs
@@ -130,6 +130,17 @@ namespace GoogleTestAdapter
         }
 
         [TestMethod]
+        [TestCategory(Unit)]
+        public void IsGoogleTestExecutable_EmptyExe_CorrectErrorHandling()
+        {
+            bool result = GoogleTestDiscoverer
+                .IsGoogleTestExecutable(TestResources.EmptyExe, "", TestEnvironment.Logger);
+
+            result.Should().BeFalse();
+            MockLogger.Verify(l => l.DebugWarning(It.Is<string>(s => s.Contains("Error while parsing imports") && s.Contains(" 0:") && s.Contains(new System.ComponentModel.Win32Exception(0).Message))));
+        }
+
+        [TestMethod]
         [TestCategory(Integration)]
         public void GetTestsFromExecutable_SampleTestsDebug_FindsTestsWithLocation()
         {

--- a/GoogleTestAdapter/Core.Tests/Helpers/DebugUtilsTests.cs
+++ b/GoogleTestAdapter/Core.Tests/Helpers/DebugUtilsTests.cs
@@ -25,6 +25,12 @@ namespace GoogleTestAdapter.Helpers
             DebugUtils.AssertIsNull("", "foo");
         }
 
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void AssertIsNull_Null_DoesNotThrow()
+        {
+            DebugUtils.AssertIsNull(null, "foo");
+        }
     }
 
 }

--- a/GoogleTestAdapter/Core.Tests/TestCases/TestCaseFactoryTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestCases/TestCaseFactoryTests.cs
@@ -41,6 +41,14 @@ namespace GoogleTestAdapter.TestCases
         }
 
         [TestMethod]
+        [TestCategory(Unit)]
+        public void CreateTestCases_OldExeDiscoveryTimeoutIsExceeded_DiscoveryIsCanceledAndCancelationIsLogged()
+        {
+            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(false);
+            CreateTestCases_DiscoveryTimeoutIsExceeded_DiscoveryIsCanceledAndCancelationIsLogged();
+        }
+
+        [TestMethod]
         [TestCategory(Integration)]
         public void CreateTestCases_OldExeWithAdditionalPdb_TestCasesAreFound()
         {

--- a/GoogleTestAdapter/Core/Helpers/ProcessExecutor.cs
+++ b/GoogleTestAdapter/Core/Helpers/ProcessExecutor.cs
@@ -24,10 +24,7 @@ namespace GoogleTestAdapter.Helpers
         private readonly IDebuggerAttacher _debuggerAttacher;
         private readonly ILogger _logger;
 
-        public ProcessExecutor(ILogger logger) : this(null, logger)
-        {
-        }
-
+        /// <param name="debuggerAttacher">Is optional (can be null).</param>
         public ProcessExecutor(IDebuggerAttacher debuggerAttacher, ILogger logger)
         {
             _debuggerAttacher = debuggerAttacher;

--- a/GoogleTestAdapter/Core/Helpers/ProcessLauncher.cs
+++ b/GoogleTestAdapter/Core/Helpers/ProcessLauncher.cs
@@ -15,28 +15,11 @@ namespace GoogleTestAdapter.Helpers
         
         private Process _process;
 
-        public ProcessLauncher(ILogger logger) : this(logger, "", null)
-        {
-        }
-
-        public ProcessLauncher(ILogger logger, string pathExtension, Action<int> reportProcessId)
+        public ProcessLauncher(ILogger logger, string pathExtension = "", Action<int> reportProcessId = null)
         {
             _logger = logger;
             _pathExtension = pathExtension;
             _reportProcessId = reportProcessId;
-        }
-
-        public List<string> GetOutputOfCommand(string command)
-        {
-            int dummy;
-            return GetOutputOfCommand("", command, "", false, false, out dummy);
-        }
-
-        public List<string> GetOutputOfCommand(string workingDirectory, string command, string param, bool printTestOutput,
-            bool throwIfError)
-        {
-            int dummy;
-            return GetOutputOfCommand(workingDirectory, command, param, printTestOutput, throwIfError, out dummy);
         }
 
         public List<string> GetOutputOfCommand(string workingDirectory, string command, string param, bool printTestOutput,

--- a/GoogleTestAdapter/EmptyExe/EmptyExe.c
+++ b/GoogleTestAdapter/EmptyExe/EmptyExe.c
@@ -1,0 +1,2 @@
+// Compile with "cl /Zl" to have a "valid" but almost empty executable file (no code, no imports, data segment with only zeros). 
+char mainCRTStartup, main;

--- a/GoogleTestAdapter/EmptyExe/EmptyExe.vcxproj
+++ b/GoogleTestAdapter/EmptyExe/EmptyExe.vcxproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8067A10E-AEBA-4C92-AC17-7D8526E91E58}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>EmptyExe</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Common.props))\Common.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="EmptyExe.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/GoogleTestAdapter/EmptyExe/EmptyExe.vcxproj.filters
+++ b/GoogleTestAdapter/EmptyExe/EmptyExe.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="EmptyExe.c" />
+  </ItemGroup>
+</Project>

--- a/GoogleTestAdapter/GoogleTestAdapter.sln
+++ b/GoogleTestAdapter/GoogleTestAdapter.sln
@@ -161,6 +161,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Donations", "Donations", "{
 		Web\Donations\thinkpad_t580.png = Web\Donations\thinkpad_t580.png
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EmptyExe", "EmptyExe\EmptyExe.vcxproj", "{8067A10E-AEBA-4C92-AC17-7D8526E91E58}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		VsPackage.Shared\VsPackage.Shared.projitems*{55294b5f-a075-43f2-b0e9-2b11925e8b91}*SharedItemsImports = 4
@@ -584,6 +586,16 @@ Global
 		{05C435E1-603C-4402-B28C-E54932F3131C}.Release|x64.Deploy.0 = Release|x64
 		{05C435E1-603C-4402-B28C-E54932F3131C}.Release|x86.ActiveCfg = Release|x64
 		{05C435E1-603C-4402-B28C-E54932F3131C}.Release|x86.Build.0 = Release|x64
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Debug|x64.ActiveCfg = Debug|x64
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Debug|x64.Build.0 = Debug|x64
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Debug|x86.ActiveCfg = Debug|Win32
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Debug|x86.Build.0 = Debug|Win32
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Release|Any CPU.ActiveCfg = Release|Win32
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Release|x64.ActiveCfg = Release|x64
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Release|x64.Build.0 = Release|x64
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Release|x86.ActiveCfg = Release|Win32
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -620,6 +632,7 @@ Global
 		{05C435E1-603C-4402-B28C-E54932F3131C} = {475245AA-A07D-41D8-BC84-959C5E12A52C}
 		{883EFE71-6B36-4813-B1DB-80D9B972B8D5} = {1F754A4D-BD42-4368-8B90-F3C03F24A2F3}
 		{58B6EF41-D226-40A9-A959-0543270D572F} = {883EFE71-6B36-4813-B1DB-80D9B972B8D5}
+		{8067A10E-AEBA-4C92-AC17-7D8526E91E58} = {475245AA-A07D-41D8-BC84-959C5E12A52C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C942DDD5-B04E-4D57-BA9F-A444392C9480}

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
@@ -187,4 +187,15 @@ namespace GoogleTestAdapter.TestAdapter
 
     }
 
+    [TestClass]
+    public class TestExecutorSequentialTests_OldTestExecutionFramework : TestExecutorSequentialTests
+    {
+        [TestInitialize]
+        public override void SetUp()
+        {
+            base.SetUp();
+            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(false);
+        }
+    }
+
 }

--- a/GoogleTestAdapter/Tests.Common/TestResources.cs
+++ b/GoogleTestAdapter/Tests.Common/TestResources.cs
@@ -28,6 +28,7 @@ namespace GoogleTestAdapter.Tests.Common
         public const string TenSecondsWaiter = GoogleTestAdapterBuildDir + @"TenSecondsWaiter\TenSecondsWaiter.exe";
         public const string AlwaysCrashingExe = GoogleTestAdapterBuildDir + @"CrashingExe\CrashingExe.exe";
         public const string AlwaysFailingExe = GoogleTestAdapterBuildDir + @"FailingExe\FailingExe.exe";
+        public const string EmptyExe = GoogleTestAdapterBuildDir + @"EmptyExe\EmptyExe.exe";
         public const string FakeGtestDllExe = GoogleTestAdapterBuildDir + @"FakeGtestDllApplication\FakeGtestDllApplication.exe";
         public const string FakeGtestDllExeX64 = GoogleTestAdapterBuildDir + @"FakeGtestDllApplication-x64\FakeGtestDllApplication-x64.exe";
         public const string SemaphoreExe = GoogleTestAdapterBuildDir + @"SemaphoreExe\SemaphoreExe.exe";


### PR DESCRIPTION
I dit 3 commits to improve covered lines (1 removing useless method, and 2 adding tests).

The last one found an inconsistent error handling when trying to get the import table from an executable file without import table, in IsGoogleTestExecutable.  It was reporting "file not found" because of the call to File.Exists before calling PeParser.FindImport; the "last error" was kept.  Note that this looks like a bug in Windows API, but it's probably better to modify the error handling here than to wait a correction in Windows API.

That test required a special source which compiles to an executable without import table.  It is clearly not ISO C.  The resulting exe could be commited if you think the source is too weird.