### PR TITLE
added preliminary support for new gtest macro GTEST_SKIP()

### DIFF
--- a/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StandardOutputTestResultParserTests.cs
@@ -102,6 +102,34 @@ namespace GoogleTestAdapter.TestResults
             @"[  PASSED  ] 2 test.",
         };
 
+        /// <summary>
+        /// <see cref="https://github.com/csoltenborn/GoogleTestAdapter/issues/260"/>
+        /// </summary>
+        private string[] ConsoleOutputWithSkippedTest { get; } = @"[==========] Running 3 tests from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 3 tests from Test
+[ RUN      ] Test.Succeed
+[       OK ] Test.Succeed (0 ms)
+[ RUN      ] Test.Skip
+[  SKIPPED ] Test.Skip (1 ms)
+[ RUN      ] Test.Fail
+C:\...\test.cpp(14): error: Value of: false
+  Actual: false
+Expected: true
+[  FAILED  ] Test.Fail (0 ms)
+[----------] 3 tests from Test (3 ms total)
+
+[----------] Global test environment tear-down
+[==========] 3 tests from 1 test suite ran. (6 ms total)
+[  PASSED  ] 1 test.
+[  SKIPPED ] 1 test, listed below:
+[  SKIPPED ] Test.Skip
+[  FAILED  ] 1 test, listed below:
+[  FAILED  ] Test.Fail
+
+ 1 FAILED TEST
+".Split('\n');
+
 
         private List<string> CrashesImmediately { get; set; }
         private List<string> CrashesAfterErrorMsg { get; set; }
@@ -274,6 +302,34 @@ namespace GoogleTestAdapter.TestResults
             XmlTestResultParserTests.AssertTestResultIsPassed(results[0]);
             results[1].TestCase.FullyQualifiedName.Should().Be("Test.A");
             XmlTestResultParserTests.AssertTestResultIsPassed(results[1]);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetTestResults_OutputWithSkippedTest_AllResultsAreFound()
+        {
+            var cases = new List<TestCase>
+            {
+                TestDataCreator.ToTestCase("Test.Succeed", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Skip", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Fail", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+            };
+
+            var results = new StandardOutputTestResultParser(cases, ConsoleOutputWithSkippedTest, TestEnvironment.Logger).GetTestResults();
+
+            results.Should().HaveCount(3);
+
+            var result = results[0];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Succeed");
+            XmlTestResultParserTests.AssertTestResultIsPassed(result);
+
+            result = results[1];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Skip");
+            XmlTestResultParserTests.AssertTestResultIsSkipped(result);
+
+            result = results[2];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Fail");
+            XmlTestResultParserTests.AssertTestResultIsFailure(result);
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/StreamingStandardOutputTestResultParserTests.cs
@@ -141,6 +141,34 @@ Expected: true
  1 FAILED TEST
 ".Split('\n');
 
+        /// <summary>
+        /// <see cref="https://github.com/csoltenborn/GoogleTestAdapter/issues/260"/>
+        /// </summary>
+        private string[] ConsoleOutputWithSkippedTestAsLastTest { get; } = @"[==========] Running 3 tests from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 3 tests from Test
+[ RUN      ] Test.Succeed
+[       OK ] Test.Succeed (0 ms)
+[ RUN      ] Test.Fail
+C:\...\test.cpp(14): error: Value of: false
+  Actual: false
+Expected: true
+[  FAILED  ] Test.Fail (0 ms)
+[ RUN      ] Test.Skip
+[  SKIPPED ] Test.Skip (1 ms)
+[----------] 3 tests from Test (3 ms total)
+
+[----------] Global test environment tear-down
+[==========] 3 tests from 1 test suite ran. (6 ms total)
+[  PASSED  ] 1 test.
+[  SKIPPED ] 1 test, listed below:
+[  SKIPPED ] Test.Skip
+[  FAILED  ] 1 test, listed below:
+[  FAILED  ] Test.Fail
+
+ 1 FAILED TEST
+".Split('\n');
+
 
         private List<string> CrashesImmediately { get; set; }
         private List<string> CrashesAfterErrorMsg { get; set; }
@@ -381,6 +409,37 @@ Expected: true
             result = results[2];
             result.TestCase.FullyQualifiedName.Should().Be("Test.Fail");
             XmlTestResultParserTests.AssertTestResultIsFailure(result);
+        }
+
+        [TestMethod]
+        [TestCategory(Unit)]
+        public void GetTestResults_OutputWithSkippedTestAsLastTest_AllResultsAreFound()
+        {
+            var cases = new List<TestCase>
+            {
+                TestDataCreator.ToTestCase("Test.Succeed", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Skip", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+                TestDataCreator.ToTestCase("Test.Fail", TestDataCreator.DummyExecutable, @"c:\somepath\source.cpp"),
+            };
+
+            var parser = new StreamingStandardOutputTestResultParser(cases, TestEnvironment.Logger, MockFrameworkReporter.Object);
+            ConsoleOutputWithSkippedTestAsLastTest.ToList().ForEach(parser.ReportLine);
+            parser.Flush();
+            var results = parser.TestResults;
+
+            results.Should().HaveCount(3);
+
+            var result = results[0];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Succeed");
+            XmlTestResultParserTests.AssertTestResultIsPassed(result);
+
+            result = results[1];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Fail");
+            XmlTestResultParserTests.AssertTestResultIsFailure(result);
+
+            result = results[2];
+            result.TestCase.FullyQualifiedName.Should().Be("Test.Skip");
+            XmlTestResultParserTests.AssertTestResultIsSkipped(result);
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
@@ -20,7 +20,7 @@ namespace GoogleTestAdapter.TestResults
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("BarSuite.BazTest1", "FooSuite.BarTest",
                 "FooSuite.BazTest", "BarSuite.BazTest2");
 
-            var parser = new XmlTestResultParser(testCases, "somefile", TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", "somefile", TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().BeEmpty();
@@ -35,7 +35,7 @@ namespace GoogleTestAdapter.TestResults
                 "GoogleTestSuiteName1.TestMethod_002");
             MockOptions.Setup(o => o.DebugMode).Returns(true);
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFileBroken, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFileBroken, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().BeEmpty();
@@ -50,7 +50,7 @@ namespace GoogleTestAdapter.TestResults
                 "GoogleTestSuiteName1.TestMethod_002");
             MockOptions.Setup(o => o.DebugMode).Returns(true);
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFileBroken_InvalidStatusAttibute, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFileBroken_InvalidStatusAttibute, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();
@@ -63,7 +63,7 @@ namespace GoogleTestAdapter.TestResults
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("GoogleTestSuiteName1.TestMethod_001", "SimpleTest.DISABLED_TestMethodDisabled");
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile1, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile1, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().HaveCount(2);
@@ -77,7 +77,7 @@ namespace GoogleTestAdapter.TestResults
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("GoogleTestSuiteName1.TestMethod_007");
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile1, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile1, TestEnvironment.Logger);
             parser.Invoking(p => p.GetTestResults()).Should().NotThrow<Exception>();
             MockLogger.Verify(l => l.LogError(It.Is<string>(s => s.Contains("Foo"))), Times.Exactly(1));
         }
@@ -88,7 +88,7 @@ namespace GoogleTestAdapter.TestResults
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("ParameterizedTestsTest1/AllEnabledTest.TestInstance/7");
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile1, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile1, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();
@@ -101,7 +101,7 @@ namespace GoogleTestAdapter.TestResults
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.ToTestCase("AnimalsTest.testGetEnoughAnimals", TestDataCreator.DummyExecutable, @"x:\prod\company\util\util.cpp").Yield();
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile1, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile1, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();
@@ -119,7 +119,7 @@ Should get three animals";
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.ToTestCase("ParameterizedTestsTest1/AllEnabledTest.TestInstance/11", TestDataCreator.DummyExecutable, @"someSimpleParameterizedTest.cpp").Yield();
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile1, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile1, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();
@@ -134,7 +134,7 @@ Should get three animals";
         {
             IEnumerable<Model.TestCase> testCases = TestDataCreator.CreateDummyTestCases("FooTest.DoesXyz");
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile2, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile2, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();
@@ -148,7 +148,7 @@ Should get three animals";
             IEnumerable<Model.TestCase> testCases = TestDataCreator.ToTestCase("FooTest.MethodBarDoesAbc", TestDataCreator.DummyExecutable,
                 @"c:\prod\gtest-1.7.0\staticallylinkedgoogletests\main.cpp").Yield();
 
-            var parser = new XmlTestResultParser(testCases, TestResources.XmlFile2, TestEnvironment.Logger);
+            var parser = new XmlTestResultParser(testCases, "someexecutable", TestResources.XmlFile2, TestEnvironment.Logger);
             List<Model.TestResult> results = parser.GetTestResults();
 
             results.Should().ContainSingle();

--- a/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
+++ b/GoogleTestAdapter/Core.Tests/TestResults/XmlTestResultParserTests.cs
@@ -171,7 +171,7 @@ Something's wrong :(";
             testResult.ErrorMessage.Should().BeNull();
         }
 
-        private void AssertTestResultIsSkipped(Model.TestResult testResult)
+        public static void AssertTestResultIsSkipped(Model.TestResult testResult)
         {
             testResult.Outcome.Should().Be(Model.TestOutcome.Skipped);
             testResult.ErrorMessage.Should().BeNull();

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -157,7 +157,7 @@ namespace GoogleTestAdapter.Runners
             var remainingTestCases =
                 arguments.TestCases.Except(streamingParser.TestResults.Select(tr => tr.TestCase));
             var testResults = new TestResultCollector(_logger, _threadName)
-                .CollectTestResults(remainingTestCases, resultXmlFile, consoleOutput, streamingParser.CrashedTestCase);
+                .CollectTestResults(remainingTestCases, executable, resultXmlFile, consoleOutput, streamingParser.CrashedTestCase);
             testResults = testResults.OrderBy(tr => tr.TestCase.FullyQualifiedName).ToList();
 
             return testResults;

--- a/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
+++ b/GoogleTestAdapter/Core/Runners/TestResultCollector.cs
@@ -18,13 +18,13 @@ namespace GoogleTestAdapter.Runners
             _threadName = threadName;
         }
 
-        public List<TestResult> CollectTestResults(IEnumerable<TestCase> testCasesRun, string resultXmlFile, List<string> consoleOutput, TestCase crashedTestCase)
+        public List<TestResult> CollectTestResults(IEnumerable<TestCase> testCasesRun, string testExecutable, string resultXmlFile, List<string> consoleOutput, TestCase crashedTestCase)
         {
             var testResults = new List<TestResult>();
             TestCase[] arrTestCasesRun = testCasesRun as TestCase[] ?? testCasesRun.ToArray();
 
             if (testResults.Count < arrTestCasesRun.Length)
-                CollectResultsFromXmlFile(arrTestCasesRun, resultXmlFile, testResults);
+                CollectResultsFromXmlFile(arrTestCasesRun, testExecutable, resultXmlFile, testResults);
 
             var consoleParser = new StandardOutputTestResultParser(arrTestCasesRun, consoleOutput, _logger);
             if (testResults.Count < arrTestCasesRun.Length)
@@ -48,9 +48,9 @@ namespace GoogleTestAdapter.Runners
             return testResults;
         }
 
-        private void CollectResultsFromXmlFile(TestCase[] testCasesRun, string resultXmlFile, List<TestResult> testResults)
+        private void CollectResultsFromXmlFile(TestCase[] testCasesRun, string testExecutable, string resultXmlFile, List<TestResult> testResults)
         {
-            var xmlParser = new XmlTestResultParser(testCasesRun, resultXmlFile, _logger);
+            var xmlParser = new XmlTestResultParser(testCasesRun, testExecutable, resultXmlFile, _logger);
             List<TestResult> xmlResults = xmlParser.GetTestResults();
             int nrOfCollectedTestResults = 0;
             foreach (TestResult testResult in xmlResults.Where(

--- a/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StandardOutputTestResultParser.cs
@@ -13,6 +13,7 @@ namespace GoogleTestAdapter.TestResults
         private const string Run = "[ RUN      ]";
         public const string Failed = "[  FAILED  ]";
         public const string Passed = "[       OK ]";
+        public const string Skipped = "[  SKIPPED ]";
 
         public const string CrashText = "!! This test has probably CRASHED !!";
 
@@ -80,7 +81,7 @@ namespace GoogleTestAdapter.TestResults
 
 
             string errorMsg = "";
-            while (!(IsFailedLine(line) || IsPassedLine(line)) && currentLineIndex <= _consoleOutput.Count)
+            while (!(IsFailedLine(line) || IsPassedLine(line) || IsSkippedLine(line)) && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
                 line = currentLineIndex < _consoleOutput.Count ? _consoleOutput[currentLineIndex] : "";
@@ -96,6 +97,10 @@ namespace GoogleTestAdapter.TestResults
             if (IsPassedLine(line))
             {
                 return CreatePassedTestResult(testCase, ParseDuration(line));
+            }
+            if (IsSkippedLine(line))
+            {
+                return CreateSkippedTestResult(testCase, ParseDuration(line));
             }
 
             CrashedTestCase = testCase;
@@ -163,6 +168,17 @@ namespace GoogleTestAdapter.TestResults
             };
         }
 
+        public static TestResult CreateSkippedTestResult(TestCase testCase, TimeSpan duration)
+        {
+            return new TestResult(testCase)
+            {
+                ComputerName = Environment.MachineName,
+                DisplayName = testCase.DisplayName,
+                Outcome = TestOutcome.Skipped,
+                Duration = duration
+            };
+        }
+
         public static TestResult CreateFailedTestResult(TestCase testCase, TimeSpan duration, string errorMessage, string errorStackTrace)
         {
             return new TestResult(testCase)
@@ -213,6 +229,11 @@ namespace GoogleTestAdapter.TestResults
         public static bool IsFailedLine(string line)
         {
             return line.StartsWith(Failed);
+        }
+
+        public static bool IsSkippedLine(string line)
+        {
+            return line.StartsWith(Skipped);
         }
 
         public static string RemovePrefix(string line)

--- a/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/StreamingStandardOutputTestResultParser.cs
@@ -130,7 +130,8 @@ namespace GoogleTestAdapter.TestResults
             string errorMsg = "";
             while (
                 !(StandardOutputTestResultParser.IsFailedLine(line)
-                    || StandardOutputTestResultParser.IsPassedLine(line))
+                    || StandardOutputTestResultParser.IsPassedLine(line)
+                    || StandardOutputTestResultParser.IsSkippedLine(line))
                 && currentLineIndex <= _consoleOutput.Count)
             {
                 errorMsg += line + "\n";
@@ -150,6 +151,12 @@ namespace GoogleTestAdapter.TestResults
             if (StandardOutputTestResultParser.IsPassedLine(line))
             {
                 return StandardOutputTestResultParser.CreatePassedTestResult(
+                    testCase,
+                    StandardOutputTestResultParser.ParseDuration(line, _logger));
+            }
+            if (StandardOutputTestResultParser.IsSkippedLine(line))
+            {
+                return StandardOutputTestResultParser.CreateSkippedTestResult(
                     testCase,
                     StandardOutputTestResultParser.ParseDuration(line, _logger));
             }

--- a/GoogleTestAdapter/Core/TestResults/XmlTestResultParser.cs
+++ b/GoogleTestAdapter/Core/TestResults/XmlTestResultParser.cs
@@ -6,9 +6,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml;
 using GoogleTestAdapter.Common;
 using GoogleTestAdapter.Model;
+using GoogleTestAdapter.Settings;
 
 namespace GoogleTestAdapter.TestResults
 {
@@ -18,17 +20,63 @@ namespace GoogleTestAdapter.TestResults
 
         private static readonly NumberFormatInfo NumberFormatInfo = new CultureInfo("en-US").NumberFormat;
 
+        private static readonly Regex SpecialCharsRegex = new Regex("[äöüÄÖÜß]+", RegexOptions.Compiled);
+
 
         private readonly ILogger _logger;
         private readonly string _xmlResultFile;
+        private readonly string _testExecutable;
         private readonly IDictionary<string, TestCase> _testCasesMap;
+        private readonly Lazy<IDictionary<string, TestCase>> _workaroundMapLazy;
 
 
-        public XmlTestResultParser(IEnumerable<TestCase> testCasesRun, string xmlResultFile, ILogger logger)
+        public XmlTestResultParser(IEnumerable<TestCase> testCasesRun, string testExecutable, string xmlResultFile, ILogger logger)
         {
             _logger = logger;
+            _testExecutable = testExecutable;
             _xmlResultFile = xmlResultFile;
             _testCasesMap = testCasesRun.ToDictionary(tc => tc.FullyQualifiedName, tc => tc);
+            _workaroundMapLazy  = new Lazy<IDictionary<string, TestCase>>(CreateWorkaroundMap);
+        }
+
+        // workaround for special chars not ending up in gtest xml output file
+        private IDictionary<string, TestCase> CreateWorkaroundMap()
+        {
+            var map = new Dictionary<string, TestCase>();
+            var duplicates = new HashSet<string>();
+            var duplicateTestCases = new List<TestCase>();
+
+            foreach (var kvp in _testCasesMap)
+            {
+                string workaroundKey = SpecialCharsRegex.Replace(kvp.Key, "");
+                if (map.ContainsKey(workaroundKey))
+                {
+                    duplicates.Add(workaroundKey);
+                    duplicateTestCases.Add(kvp.Value);
+                }
+                else
+                {
+                    map[workaroundKey] = kvp.Value;
+                }
+            }
+
+            foreach (var duplicate in duplicates)
+            {
+                duplicateTestCases.Add(map[duplicate]);
+                map.Remove(duplicate);
+            }
+
+            if (duplicateTestCases.Any())
+            {
+                string message =
+                    $"Executable {_testExecutable} has test names containing characters which happen to not end up in the XML file produced by Google Test. " +
+                    "This has caused ambiguities while resolving the according test results, which are thus not available. " + 
+                    $"Note that this problem does not occur if GTA option '{SettingsWrapper.OptionUseNewTestExecutionFramework}' is enabled." +
+                    $"\nThe following tests are affected: {string.Join(", ", duplicateTestCases.Select(tc => tc.FullyQualifiedName).OrderBy(n => n))}";
+                _logger.LogWarning(message);
+            }
+
+            return map;
         }
 
 
@@ -99,8 +147,11 @@ namespace GoogleTestAdapter.TestResults
             string qualifiedName = GetQualifiedName(testcaseNode);
 
             TestCase testCase;
-            if (!_testCasesMap.TryGetValue(qualifiedName, out testCase))
+            if (!_testCasesMap.TryGetValue(qualifiedName, out testCase) &&
+                !_workaroundMapLazy.Value.TryGetValue(qualifiedName, out testCase))
+            {
                 return null;
+            }
 
             var testResult = new TestResult(testCase)
             {

--- a/GoogleTestAdapter/Packaging.GTA/VsPackage.nuspec
+++ b/GoogleTestAdapter/Packaging.GTA/VsPackage.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8">
     <id>GoogleTestAdapter</id>
-    <version>0.14.2</version>
+    <version>0.14.3</version>
     <title>Google Test Adapter</title>
     <authors>Christian Soltenborn</authors>
     <owners>Christian Soltenborn</owners>

--- a/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -41,23 +41,23 @@
   </PropertyGroup>
   <Choose>
     <When Condition="'$(TestAdapterFlavor)' == 'GTA'">
-	  <ItemGroup>
-		<Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-		  <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-		  <Private>True</Private>
-		</Reference>
-	  </ItemGroup>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
     </When>
     <Otherwise>
-	  <ItemGroup>
-		<Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-		  <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.1\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
-		</Reference>
-		<Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-		  <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.1\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-		  <Private>True</Private>
-		</Reference>
-	  </ItemGroup>
+      <ItemGroup>
+        <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.1\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>$(NuGetPackages)Microsoft.TestPlatform.ObjectModel.15.0.1\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
@@ -99,6 +99,7 @@
     <Compile Include="ProcessExecution\NativeDebuggedProcessExecutorTests.cs" />
     <Compile Include="Settings\RunSettingsContainerTests.cs" />
     <Compile Include="CommonFunctionsTests.cs" />
+    <Compile Include="TestExecutorSequentialTests_FrameworkDebugging.cs" />
     <Compile Include="TestExecutorTestsBase.cs" />
     <Compile Include="TestAdapterTestsBase.cs" />
     <Compile Include="Framework\VsTestFrameworkReporterTests.cs" />

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
@@ -46,14 +46,14 @@ namespace GoogleTestAdapter.TestAdapter
 
         [TestMethod]
         [TestCategory(Integration)]
-        public void RunTests_CancelingExecutor_StopsTestExecution()
+        public virtual void RunTests_CancelingExecutor_StopsTestExecution()
         {
             DoRunCancelingTests(false, DurationOfEachLongRunningTestInMs);  // (only) 1st test should be executed
         }
 
         [TestMethod]
         [TestCategory(Integration)]
-        public void RunTests_CancelingExecutorAndKillProcesses_StopsTestExecutionFaster()
+        public virtual void RunTests_CancelingExecutorAndKillProcesses_StopsTestExecutionFaster()
         {
             DoRunCancelingTests(true, WaitBeforeCancelInMs);  // 1st test should be actively canceled
         }
@@ -123,14 +123,14 @@ namespace GoogleTestAdapter.TestAdapter
 
         [TestMethod]
         [TestCategory(Integration)]
-        public void RunTests_CrashingX64Tests_CorrectTestResults()
+        public virtual void RunTests_CrashingX64Tests_CorrectTestResults()
         {
             RunAndVerifyTests(TestResources.CrashingTests_ReleaseX64, 1, 2, 0, 3);
         }
 
         [TestMethod]
         [TestCategory(Integration)]
-        public void RunTests_CrashingX86Tests_CorrectTestResults()
+        public virtual void RunTests_CrashingX86Tests_CorrectTestResults()
         {
             RunAndVerifyTests(TestResources.CrashingTests_ReleaseX86, 1, 2, 0, 3);
         }
@@ -186,16 +186,4 @@ namespace GoogleTestAdapter.TestAdapter
         #endregion
 
     }
-
-    [TestClass]
-    public class TestExecutorSequentialTests_OldTestExecutionFramework : TestExecutorSequentialTests
-    {
-        [TestInitialize]
-        public override void SetUp()
-        {
-            base.SetUp();
-            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(false);
-        }
-    }
-
 }

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests_FrameworkDebugging.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests_FrameworkDebugging.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using GoogleTestAdapter.Helpers;
+using GoogleTestAdapter.Tests.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace GoogleTestAdapter.TestAdapter
+{
+    [TestClass]
+    public class TestExecutorSequentialTests_FrameworkDebugging : TestExecutorSequentialTests
+    {
+        [TestInitialize]
+        public override void SetUp()
+        {
+            base.SetUp();
+            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(false);
+
+            MockRunContext.Setup(c => c.IsBeingDebugged).Returns(true);
+            SetUpMockFrameworkHandle();
+        }
+
+        protected override void SetUpMockFrameworkHandle()
+        {
+            MockFrameworkHandle.Setup(
+                    h => h.LaunchProcessWithDebuggerAttached(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<IDictionary<string, string>>()))
+                .Returns((string filePath,
+                    string workingDirectory,
+                    string arguments,
+                    IDictionary<string, string> environmentVariables) =>
+                {
+                    var processStartInfo = new ProcessStartInfo(filePath, arguments)
+                    {
+                        WorkingDirectory = workingDirectory,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    foreach (var kvp in environmentVariables)
+                    {
+                        processStartInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                    }
+
+                    var process = new Process {StartInfo = processStartInfo};
+                    if (!process.Start())
+                        throw new Exception("WTF!");
+                    return process.Id;
+                });
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_CrashingX64Tests_CorrectTestResults()
+        {
+            // test crashes, no info available if debugged via framework 
+            RunAndVerifyTests(TestResources.CrashingTests_ReleaseX64, 0, 0, 0);
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_CrashingX86Tests_CorrectTestResults()
+        {
+            // test crashes, no info available if debugged via framework 
+            RunAndVerifyTests(TestResources.CrashingTests_ReleaseX86, 0, 0, 0);
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_HardCrashingX86Tests_CorrectTestResults()
+        {
+            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            executor.RunTests(TestResources.CrashingTests_DebugX86.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
+
+            // test crashes, no info available if debugged via framework 
+            CheckMockInvocations(0, 0, 0, 0);
+        }
+
+        #region Method stubs for code coverage
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_ExternallyLinkedX64_CorrectTestResults()
+        {
+            base.RunTests_ExternallyLinkedX64_CorrectTestResults();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_ExternallyLinkedX86TestsInDebugMode_CorrectTestResults()
+        {
+            base.RunTests_ExternallyLinkedX86TestsInDebugMode_CorrectTestResults();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_ExternallyLinkedX86Tests_CorrectTestResults()
+        {
+            base.RunTests_ExternallyLinkedX86Tests_CorrectTestResults();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_StaticallyLinkedX64Tests_CorrectTestResults()
+        {
+            base.RunTests_StaticallyLinkedX64Tests_CorrectTestResults();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_StaticallyLinkedX86Tests_CorrectTestResults()
+        {
+            base.RunTests_StaticallyLinkedX86Tests_CorrectTestResults();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_TestDirectoryViaUserParams_IsPassedViaCommandLineArg()
+        {
+            base.RunTests_TestDirectoryViaUserParams_IsPassedViaCommandLineArg();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithNonexistingSetupBatch_LogsError()
+        {
+            base.RunTests_WithNonexistingSetupBatch_LogsError();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithPathExtension_ExecutionOk()
+        {
+            base.RunTests_WithPathExtension_ExecutionOk();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithSetupAndTeardownBatchesWhereSetupFails_LogsWarning()
+        {
+            base.RunTests_WithSetupAndTeardownBatchesWhereSetupFails_LogsWarning();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithSetupAndTeardownBatchesWhereTeardownFails_LogsWarning()
+        {
+            base.RunTests_WithSetupAndTeardownBatchesWhereTeardownFails_LogsWarning();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithoutBatches_NoLogging()
+        {
+            base.RunTests_WithoutBatches_NoLogging();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WithoutPathExtension_ExecutionFails()
+        {
+            base.RunTests_WithoutPathExtension_ExecutionFails();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_WorkingDir_IsSetCorrectly()
+        {
+            base.RunTests_WorkingDir_IsSetCorrectly();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_CancelingExecutorAndKillProcesses_StopsTestExecutionFaster()
+        {
+            base.RunTests_CancelingExecutorAndKillProcesses_StopsTestExecutionFaster();
+        }
+
+        [TestMethod]
+        [TestCategory(TestMetadata.TestCategories.Integration)]
+        public override void RunTests_CancelingExecutor_StopsTestExecution()
+        {
+            base.RunTests_CancelingExecutor_StopsTestExecution();
+        }
+
+        #endregion
+    }
+}

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorTestsBase.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorTestsBase.cs
@@ -37,6 +37,10 @@ namespace GoogleTestAdapter.TestAdapter
                 Times.Exactly(nrOfUnexecutedTests));
         }
 
+        protected virtual void SetUpMockFrameworkHandle()
+        {
+        }
+
         [TestInitialize]
         public override void SetUp()
         {
@@ -67,6 +71,7 @@ namespace GoogleTestAdapter.TestAdapter
             RunAndVerifySingleTest(testCase, VsTestOutcome.Failed);
 
             MockFrameworkHandle.Reset();
+            SetUpMockFrameworkHandle();
             MockOptions.Setup(o => o.AdditionalTestExecutionParam).Returns("-testdirectory=\"" + SettingsWrapper.TestDirPlaceholder + "\"");
 
             RunAndVerifySingleTest(testCase, VsTestOutcome.Passed);
@@ -82,7 +87,9 @@ namespace GoogleTestAdapter.TestAdapter
             RunAndVerifySingleTest(testCase, VsTestOutcome.Failed);
 
             MockFrameworkHandle.Reset();
+            SetUpMockFrameworkHandle();
             MockOptions.Setup(o => o.WorkingDir).Returns(SettingsWrapper.SolutionDirPlaceholder);
+
             RunAndVerifySingleTest(testCase, VsTestOutcome.Passed);
         }
 

--- a/GoogleTestAdapter/VsPackage.GTA/ReleaseNotes/Donations.cs
+++ b/GoogleTestAdapter/VsPackage.GTA/ReleaseNotes/Donations.cs
@@ -13,11 +13,14 @@ In the last couple of months, I noticed that my private laptop certainly has a f
 Therefore, if you would like to appreciate development and support of <i>Google Test Adapter</i>, <b>please consider to [donate!](https://github.com/csoltenborn/GoogleTestAdapter#donations)</b> Thanks in advance...
 <br>
 <br>
+<b>Update (2/5/2019):</b> I have again received some (and quite generous) donations - thanks a lot to Treb and Sebastian! Still not at my donation goal, though... If you happen to work with GTA in a professional manner (e.g. in a company which uses GTA to execute the C++ tests, be it within Visual Studio or on the build server), may I ask you to reconsider donating? If you need some more motivation, note that my birthday was just a couple of days ago ;-)
+<br>
+<br>
+<b>Update (2/5/2019):</b> Welcome again to my donation weekly soap :-) Responds to my last request for donations were quite a bit better and included some rather generous ones, but still a way to go until my donation goals are met. Thanks a lot to Yehuda, Walter, Thomas, Lewis, Greg, and my colleague Benedikt! I loved to hear that GTA just works for you and is indeed quite helpful.
+<br>
+<br>
 <b>Update (12/09/2018):</b> Given the fact that I have a couple of thousands users, I must admit that I have been unpleasantly surprised by the amount of donations I received (thanks, Tim and
 Arne! I appreciate it more than you might imagine). Thus, I have decided to disable the <i>Do not show release notes</i> option until I have reached my donation goals (sorry for this, Tim and Arne). Please consider to [donate](https://github.com/csoltenborn/GoogleTestAdapter#donations) - and note that Christmas is pretty close ;-)
-<br>
-<br>
-<b>Update (12/16/2018):</b> Welcome again to my donation weekly soap :-) Responds to my last request for donations were quite a bit better and included some rather generous ones, but still a way to go until my donation goals are met. Thanks a lot to Yehuda, Walter, Thomas, Lewis, Greg, and my colleague Benedikt! I loved to hear that GTA just works for you and is indeed quite helpful.
 <br>
 <br>
 ";

--- a/GoogleTestAdapter/VsPackage.GTA/ReleaseNotes/History.cs
+++ b/GoogleTestAdapter/VsPackage.GTA/ReleaseNotes/History.cs
@@ -63,7 +63,8 @@ namespace GoogleTestAdapter.VsPackage.ReleaseNotes
                 { new Version(0, 13, 4), new DateTime(2018, 8, 4) },
                 { new Version(0, 14, 0), new DateTime(2018, 12, 9) },
                 { new Version(0, 14, 1), new DateTime(2018, 12, 10) },
-                { new Version(0, 14, 2), new DateTime(2018, 12, 16) }
+                { new Version(0, 14, 2), new DateTime(2018, 12, 16) },
+                { new Version(0, 14, 3), new DateTime(2019, 2, 5) }
             };
         }
 

--- a/GoogleTestAdapter/VsPackage.GTA/Resources/ReleaseNotes/0.14.3.md
+++ b/GoogleTestAdapter/VsPackage.GTA/Resources/ReleaseNotes/0.14.3.md
@@ -1,0 +1,5 @@
+**Announcement:** Microsoft has decided to force VS extensions to make use of [asynchronous package loading](https://blogs.msdn.microsoft.com/visualstudio/2018/05/16/improving-the-responsiveness-of-critical-scenarios-by-updating-auto-load-behavior-for-extensions/). Since they only provide backwards compatibility for this down to VS2013, 0.14.* will be **the last version with support for VS2012**. Support for asynchronous package loading will be added in the next version of GTA.
+
+Changes in this version:
+* enhancement: GTA now also supports the (not yet released) macro `GTEST_SKIP()` ([#260](https://github.com/csoltenborn/GoogleTestAdapter/issues/260), thanks to [Sixten Hilborn](https://github.com/sixten-hilborn) for report and testing)
+* bugfix: some broken links of the README have been fixed ([#257](https://github.com/csoltenborn/GoogleTestAdapter/issues/257) and [#258](https://github.com/csoltenborn/GoogleTestAdapter/issues/258), thanks to [Jim Orcheson](https://github.com/jimorc) for report and pull request)

--- a/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
+++ b/GoogleTestAdapter/VsPackage.GTA/VsPackage.GTA.csproj
@@ -221,6 +221,9 @@
     <Content Include="Resources\ReleaseNotes\0.14.2.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\ReleaseNotes\0.14.3.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="GoogleTestExtensionOptionsPage.vsct">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/8hdgmdy1ogqi606j/branch/master?svg=true)](https://ci.appveyor.com/project/csoltenborn/googletestadapter-u1cxh/branch/master)
 [![Code coverage](https://codecov.io/gh/csoltenborn/GoogleTestAdapter/branch/master/graph/badge.svg)](https://codecov.io/gh/csoltenborn/GoogleTestAdapter)
-[![Visual Studio Marketplace downloads](https://img.shields.io/badge/vs_marketplace-106k-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter)
+[![Visual Studio Marketplace downloads](https://img.shields.io/badge/vs_marketplace-112k-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter)
 [![NuGet downloads](https://img.shields.io/nuget/dt/GoogleTestAdapter.svg?colorB=0c7dbe&label=nuget)](https://www.nuget.org/packages/GoogleTestAdapter)
 
 
@@ -49,19 +49,19 @@ Please note that I will see your donations as appreciation of my work so far and
 
 #### Installation
 
-[![Download from Visual Studio Marketplace](https://img.shields.io/badge/vs_marketplace-v0.14.2-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter)
+[![Download from Visual Studio Marketplace](https://img.shields.io/badge/vs_marketplace-v0.14.3-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter)
 [![Download from NuGet](https://img.shields.io/nuget/vpre/GoogleTestAdapter.svg?colorB=0c7dbe&label=nuget)](https://www.nuget.org/packages/GoogleTestAdapter)
 [![Download from GitHub](https://img.shields.io/github/release/csoltenborn/GoogleTestAdapter/all.svg?colorB=0c7dbe&label=github)](https://github.com/csoltenborn/GoogleTestAdapter/releases)
 
 Google Test Adapter can be installed in three ways:
 
 * Install through the Visual Studio Marketplace at *Tools/Extensions and Updates* - search for *Google Test Adapter*.
-* Download and launch the VSIX installer from either the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter) or [GitHub](https://github.com/csoltenborn/GoogleTestAdapter/releases/download/v0.14.2/GoogleTestAdapter-0.14.2.vsix)
+* Download and launch the VSIX installer from either the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ChristianSoltenborn.GoogleTestAdapter) or [GitHub](https://github.com/csoltenborn/GoogleTestAdapter/releases/download/v0.14.3/GoogleTestAdapter-0.14.3.vsix)
 * Add a NuGet dependency to the [Google test adapter nuget package](https://www.nuget.org/packages/GoogleTestAdapter/) to your Google Test projects. Note, however, that Visual Studio integration is limited this way: VS can discover and run tests, but no debugging, options or toolbar will be available; configuration is only possible through solution config files (see below).
 
 After restarting VS, your tests will be displayed in the Test Explorer at build completion time. If no or not all tests show up, have a look at the [trouble shooting section](#trouble_shooting).
 
-Note that due to Microsoft requiring VS extensions to support [asynchronous package loading](https://blogs.msdn.microsoft.com/visualstudio/2018/05/16/improving-the-responsiveness-of-critical-scenarios-by-updating-auto-load-behavior-for-extensions/), the last version of Google Test Adapter which supports Visual Studio 2012 is [0.14.2](https://github.com/csoltenborn/GoogleTestAdapter/releases/tag/v0.14.2).
+Note that due to Microsoft requiring VS extensions to support [asynchronous package loading](https://blogs.msdn.microsoft.com/visualstudio/2018/05/16/improving-the-responsiveness-of-critical-scenarios-by-updating-auto-load-behavior-for-extensions/), the last version of Google Test Adapter which supports Visual Studio 2012 is [0.14.3](https://github.com/csoltenborn/GoogleTestAdapter/releases/tag/v0.14.3).
 
 
 #### <a name="gta_configuration"></a>Configuration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.14.2.{build}
+version: 0.14.3.{build}
 os: 
 - Visual Studio 2017
 configuration: Release


### PR DESCRIPTION
Added support for GTEST_SKIP() macro (not yet released) - this takes case of #260 

@sixten-hilborn: Would you mind to give it a try? You can download the according build artifacts from [here](https://ci.appveyor.com/project/csoltenborn/googletestadapter-u1cxh/builds/22073380/artifacts)...

As a side note: I have not tested this on the actual adapter, but merely adjusted the output parsers and provided according unit tests. However, the skipped tests have been marked as failures before the patch, but not as test crashes. Is the skipped test indeed marked as "probably CRASHED" for the minimal example you provided, or is there anything special about the test which made you report the issue in the first place?