### PR TITLE
test output is (only) printed by process executors (except framework-based debugging)

### DIFF
--- a/GoogleTestAdapter/Core/ProcessExecution/DotNetProcessExecutor.cs
+++ b/GoogleTestAdapter/Core/ProcessExecution/DotNetProcessExecutor.cs
@@ -16,6 +16,17 @@ namespace GoogleTestAdapter.ProcessExecution
         
         private Process _process;
 
+        public static void LogStartOfOutput(ILogger logger, string command, string parameters)
+        {
+            logger.LogInfo(
+                ">>>>>>>>>>>>>>> Output of command '" + command + " " + parameters + "'");
+        }
+
+        public static void LogEndOfOutput(ILogger logger)
+        {
+            logger.LogInfo("<<<<<<<<<<<<<<< End of Output");
+        }
+
         public DotNetProcessExecutor(bool printTestOutput, ILogger logger)
         {
             _printTestOutput = printTestOutput;
@@ -67,8 +78,7 @@ namespace GoogleTestAdapter.ProcessExecution
 
                 if (_printTestOutput)
                 {
-                    _logger.LogInfo(
-                        ">>>>>>>>>>>>>>> Output of command '" + command + " " + parameters + "'");
+                    LogStartOfOutput(_logger, command, parameters);
                 }
 
                 _process.Start();
@@ -81,7 +91,7 @@ namespace GoogleTestAdapter.ProcessExecution
                 {
                     if (_printTestOutput)
                     {
-                        _logger.LogInfo("<<<<<<<<<<<<<<< End of Output");
+                        LogEndOfOutput(_logger);
                     }
                     return _process.ExitCode;
                 }

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -172,17 +172,11 @@ namespace GoogleTestAdapter.Runners
                                    !_settings.ParallelTestExecution &&
                                    isTestOutputAvailable;
 
-            if (printTestOutput)
-                _logger.LogInfo(
-                    $"{_threadName}>>>>>>>>>>>>>>> Output of command '" + executable + " " + arguments.CommandLine + "'");
-
             void OnNewOutputLine(string line)
             {
                 try
                 {
                     if (!_canceled) streamingParser.ReportLine(line);
-
-                    if (printTestOutput) _logger.LogInfo(line);
                 }
                 catch (TestRunCanceledException e)
                 {
@@ -196,13 +190,11 @@ namespace GoogleTestAdapter.Runners
                     ? processExecutorFactory.CreateNativeDebuggingExecutor(printTestOutput, _logger)
                     : processExecutorFactory.CreateFrameworkDebuggingExecutor(printTestOutput, _logger)
                 : processExecutorFactory.CreateExecutor(printTestOutput, _logger);
+
             _processExecutor.ExecuteCommandBlocking(
                 executable, arguments.CommandLine, workingDir, pathExtension,
                 isTestOutputAvailable ? (Action<string>) OnNewOutputLine : null);
             streamingParser.Flush();
-
-            if (printTestOutput)
-                _logger.LogInfo($"{_threadName}<<<<<<<<<<<<<<< End of Output");
 
             var consoleOutput = new List<string>();
             new TestDurationSerializer().UpdateTestDurations(streamingParser.TestResults);

--- a/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
+++ b/GoogleTestAdapter/Core/TestCases/TestCaseFactory.cs
@@ -197,7 +197,7 @@ namespace GoogleTestAdapter.TestCases
                 return testCase;
             }
 
-            _logger.LogWarning($"Could not find source location for test {descriptor.FullyQualifiedName}");
+            _logger.LogWarning($"Could not find source location for test {descriptor.FullyQualifiedName}, executable: {_executable}");
             return CreateTestCase(descriptor);
         }
 

--- a/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestAdapter.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ProcessExecution\NativeDebuggedProcessExecutorTests.cs" />
     <Compile Include="Settings\RunSettingsContainerTests.cs" />
     <Compile Include="CommonFunctionsTests.cs" />
+    <Compile Include="TestExecutorSequentialTests_NativeDebugging.cs" />
     <Compile Include="TestExecutorSequentialTests_FrameworkDebugging.cs" />
     <Compile Include="TestExecutorTestsBase.cs" />
     <Compile Include="TestAdapterTestsBase.cs" />

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorParallelTests.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorParallelTests.cs
@@ -51,7 +51,7 @@ namespace GoogleTestAdapter.TestAdapter
             MockOptions.Setup(o => o.ParallelTestExecution).Returns(false);
 
             Stopwatch stopwatch = new Stopwatch();
-            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
             IEnumerable<string> testsToRun = TestResources.LongRunningTests_ReleaseX86.Yield();
             stopwatch.Start();
             executor.RunTests(testsToRun, MockRunContext.Object, MockFrameworkHandle.Object);
@@ -61,7 +61,7 @@ namespace GoogleTestAdapter.TestAdapter
             MockOptions.Setup(o => o.ParallelTestExecution).Returns(true);
             MockOptions.Setup(o => o.MaxNrOfThreads).Returns(Environment.ProcessorCount);
 
-            executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
             testsToRun = TestResources.LongRunningTests_ReleaseX86.Yield();
             stopwatch.Restart();
             executor.RunTests(testsToRun, MockRunContext.Object, MockFrameworkHandle.Object);
@@ -110,6 +110,12 @@ namespace GoogleTestAdapter.TestAdapter
         public override void RunTests_StaticallyLinkedX64Tests_CorrectTestResults()
         {
             base.RunTests_StaticallyLinkedX64Tests_CorrectTestResults();
+        }
+
+        [TestMethod]
+        public override void RunTests_StaticallyLinkedX64Tests_OutputIsPrintedAtMostOnce()
+        {
+            base.RunTests_StaticallyLinkedX64Tests_OutputIsPrintedAtMostOnce();
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests.cs
@@ -65,7 +65,7 @@ namespace GoogleTestAdapter.TestAdapter
             testCasesToRun.Should().HaveCount(2);
 
             var stopwatch = new Stopwatch();
-            var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
 
             var canceller = new Thread(() =>
             {
@@ -119,6 +119,12 @@ namespace GoogleTestAdapter.TestAdapter
         public override void RunTests_StaticallyLinkedX64Tests_CorrectTestResults()
         {
             base.RunTests_StaticallyLinkedX64Tests_CorrectTestResults();
+        }        
+        
+        [TestMethod]
+        public override void RunTests_StaticallyLinkedX64Tests_OutputIsPrintedAtMostOnce()
+        {
+            base.RunTests_StaticallyLinkedX64Tests_OutputIsPrintedAtMostOnce();
         }
 
         [TestMethod]

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests_NativeDebugging.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorSequentialTests_NativeDebugging.cs
@@ -9,13 +9,13 @@ using Moq;
 namespace GoogleTestAdapter.TestAdapter
 {
     [TestClass]
-    public class TestExecutorSequentialTests_FrameworkDebugging : TestExecutorSequentialTests
+    public class TestExecutorSequentialTests_NativeDebugging : TestExecutorSequentialTests
     {
         [TestInitialize]
         public override void SetUp()
         {
             base.SetUp();
-            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(false);
+            MockOptions.Setup(o => o.UseNewTestExecutionFramework).Returns(true);
 
             MockRunContext.Setup(c => c.IsBeingDebugged).Returns(true);
             SetUpMockFrameworkHandle();
@@ -56,27 +56,21 @@ namespace GoogleTestAdapter.TestAdapter
         [TestCategory(TestMetadata.TestCategories.Integration)]
         public override void RunTests_CrashingX64Tests_CorrectTestResults()
         {
-            // test crashes, no info available if debugged via framework 
-            RunAndVerifyTests(TestResources.CrashingTests_ReleaseX64, 0, 0, 0);
+            base.RunTests_CrashingX64Tests_CorrectTestResults();
         }
 
         [TestMethod]
         [TestCategory(TestMetadata.TestCategories.Integration)]
         public override void RunTests_CrashingX86Tests_CorrectTestResults()
         {
-            // test crashes, no info available if debugged via framework 
-            RunAndVerifyTests(TestResources.CrashingTests_ReleaseX86, 0, 0, 0);
+            base.RunTests_CrashingX86Tests_CorrectTestResults();
         }
 
         [TestMethod]
         [TestCategory(TestMetadata.TestCategories.Integration)]
         public override void RunTests_HardCrashingX86Tests_CorrectTestResults()
         {
-            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
-            executor.RunTests(TestResources.CrashingTests_DebugX86.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
-
-            // test crashes, no info available if debugged via framework 
-            CheckMockInvocations(0, 0, 0, 0);
+            base.RunTests_HardCrashingX86Tests_CorrectTestResults();
         }
 
         #region Method stubs for code coverage

--- a/GoogleTestAdapter/TestAdapter.Tests/TestExecutorTestsBase.cs
+++ b/GoogleTestAdapter/TestAdapter.Tests/TestExecutorTestsBase.cs
@@ -7,6 +7,7 @@ using GoogleTestAdapter.Helpers;
 using GoogleTestAdapter.Runners;
 using GoogleTestAdapter.Model;
 using GoogleTestAdapter.Settings;
+using GoogleTestAdapter.TestAdapter.ProcessExecution;
 using GoogleTestAdapter.Tests.Common;
 using VsTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
 using VsTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
@@ -17,6 +18,8 @@ namespace GoogleTestAdapter.TestAdapter
 {
     public abstract class TestExecutorTestsBase : TestAdapterTestsBase
     {
+        protected readonly Mock<IDebuggerAttacher> MockDebuggerAttacher = new Mock<IDebuggerAttacher>();
+
         private readonly bool _parallelTestExecution;
 
         private readonly int _maxNrOfThreads;
@@ -48,11 +51,14 @@ namespace GoogleTestAdapter.TestAdapter
 
             MockOptions.Setup(o => o.ParallelTestExecution).Returns(_parallelTestExecution);
             MockOptions.Setup(o => o.MaxNrOfThreads).Returns(_maxNrOfThreads);
+
+            MockDebuggerAttacher.Reset();
+            MockDebuggerAttacher.Setup(a => a.AttachDebugger(It.IsAny<int>())).Returns(true);
         }
 
         private void RunAndVerifySingleTest(TestCase testCase, VsTestOutcome expectedOutcome)
         {
-            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
             executor.RunTests(testCase.ToVsTestCase().Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
 
             foreach (VsTestOutcome outcome in Enum.GetValues(typeof(VsTestOutcome)))
@@ -136,9 +142,29 @@ namespace GoogleTestAdapter.TestAdapter
 
         [TestMethod]
         [TestCategory(Integration)]
+        public virtual void RunTests_StaticallyLinkedX64Tests_OutputIsPrintedAtMostOnce()
+        {
+            MockOptions.Setup(o => o.PrintTestOutput).Returns(true);
+            MockOptions.Setup(o => o.DebugMode).Returns(false);
+
+            RunAndVerifyTests(TestResources.Tests_ReleaseX64, TestResources.NrOfPassingTests, TestResources.NrOfFailingTests, 0);
+
+            bool isTestOutputAvailable =
+                !MockOptions.Object.ParallelTestExecution &&
+                (MockOptions.Object.UseNewTestExecutionFramework || !MockRunContext.Object.IsBeingDebugged);
+            int nrOfExpectedLines = isTestOutputAvailable ? 1 : 0;
+            
+            MockLogger.Verify(l => l.LogInfo(It.Is<string>(line => line == "[----------] Global test environment set-up.")), Times.Exactly(nrOfExpectedLines));
+
+            MockLogger.Verify(l => l.LogInfo(It.Is<string>(line => line.StartsWith(">>>>>>>>>>>>>>> Output of command"))), Times.Exactly(nrOfExpectedLines));
+            MockLogger.Verify(l => l.LogInfo(It.Is<string>(line => line.StartsWith("<<<<<<<<<<<<<<< End of Output"))), Times.Exactly(nrOfExpectedLines));
+        }
+
+        [TestMethod]
+        [TestCategory(Integration)]
         public virtual void RunTests_HardCrashingX86Tests_CorrectTestResults()
         {
-            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
             executor.RunTests(TestResources.CrashingTests_DebugX86.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
 
             CheckMockInvocations(1, 2, 0, 3);
@@ -227,7 +253,7 @@ namespace GoogleTestAdapter.TestAdapter
                 string targetExe = TestDataCreator.GetPathExtensionExecutable(baseDir);
                 MockOptions.Setup(o => o.PathExtension).Returns(SettingsWrapper.ExecutableDirPlaceholder + @"\..\dll");
 
-                var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+                var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
                 executor.RunTests(targetExe.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
 
                 MockFrameworkHandle.Verify(h => h.RecordResult(It.Is<VsTestResult>(tr => tr.Outcome == VsTestOutcome.Passed)), Times.Once);
@@ -249,7 +275,7 @@ namespace GoogleTestAdapter.TestAdapter
             {
                 string targetExe = TestDataCreator.GetPathExtensionExecutable(baseDir);
 
-                var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+                var executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
                 executor.RunTests(targetExe.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
 
                 MockFrameworkHandle.Verify(h => h.RecordResult(It.IsAny<VsTestResult>()), Times.Never);
@@ -263,7 +289,7 @@ namespace GoogleTestAdapter.TestAdapter
 
         protected void RunAndVerifyTests(string executable, int nrOfPassedTests, int nrOfFailedTests, int nrOfUnexecutedTests, int nrOfSkippedTests = 0, bool checkNoErrorsLogged = true)
         {
-            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options);
+            TestExecutor executor = new TestExecutor(TestEnvironment.Logger, TestEnvironment.Options, MockDebuggerAttacher.Object);
             executor.RunTests(executable.Yield(), MockRunContext.Object, MockFrameworkHandle.Object);
 
             if (checkNoErrorsLogged)

--- a/GoogleTestAdapter/TestAdapter/ProcessExecution/FrameworkDebuggedProcessExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/ProcessExecution/FrameworkDebuggedProcessExecutor.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using GoogleTestAdapter.Common;
 using GoogleTestAdapter.Helpers;
 using GoogleTestAdapter.ProcessExecution.Contracts;
+using GoogleTestAdapter.Settings;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace GoogleTestAdapter.TestAdapter.ProcessExecution
@@ -43,7 +44,7 @@ namespace GoogleTestAdapter.TestAdapter.ProcessExecution
             if (_printTestOutput)
             {
                 _logger.DebugInfo(
-                    "Note that due to restrictions of the VsTest framework, the test executable's output can not be displayed in the test console when debugging tests!");
+                    $"Note that due to restrictions of the VsTest framework, the test executable's output can not be displayed in the test console when debugging tests. Use '{SettingsWrapper.OptionUseNewTestExecutionFramework}' option to overcome this problem.'");
             }
 
             _processId = _frameworkHandle.LaunchProcessWithDebuggerAttached(command, workingDir, parameters, envVariables);

--- a/GoogleTestAdapter/TestAdapter/ProcessExecution/NativeDebuggedProcessExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/ProcessExecution/NativeDebuggedProcessExecutor.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using GoogleTestAdapter.Common;
 using GoogleTestAdapter.Helpers;
+using GoogleTestAdapter.ProcessExecution;
 using GoogleTestAdapter.ProcessExecution.Contracts;
 using Microsoft.Win32.SafeHandles;
 
@@ -121,6 +122,11 @@ namespace GoogleTestAdapter.TestAdapter.ProcessExecution
                             logger.LogError($"Could not attach debugger to process {processInfo.dwProcessId}");
                         }
 
+                        if (printTestOutput)
+                        {
+                            DotNetProcessExecutor.LogStartOfOutput(logger, command, parameters);
+                        }
+
                         ResumeThread(thread);
 
                         using (var reader = new StreamReader(pipeStream, Encoding.Default))
@@ -140,8 +146,13 @@ namespace GoogleTestAdapter.TestAdapter.ProcessExecution
 
                         WaitForSingleObject(process, INFINITE);
 
+                        if (printTestOutput)
+                        {
+                            DotNetProcessExecutor.LogEndOfOutput(logger);
+                        }
+
                         int exitCode;
-                        if(!GetExitCodeProcess(process, out exitCode))
+                        if (!GetExitCodeProcess(process, out exitCode))
                             throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not get exit code of process");
 
                         return exitCode;

--- a/GoogleTestAdapter/TestAdapter/TestExecutor.cs
+++ b/GoogleTestAdapter/TestAdapter/TestExecutor.cs
@@ -28,17 +28,19 @@ namespace GoogleTestAdapter.TestAdapter
 
         private ILogger _logger;
         private SettingsWrapper _settings;
+        private readonly IDebuggerAttacher _debuggerAttacher;
         private GoogleTestExecutor _executor;
 
         private bool _canceled;
 
         // ReSharper disable once UnusedMember.Global
-        public TestExecutor() : this(null, null) { }
+        public TestExecutor() : this(null, null, null) { }
 
-        public TestExecutor(ILogger logger, SettingsWrapper settings)
+        public TestExecutor(ILogger logger, SettingsWrapper settings, IDebuggerAttacher debuggerAttacher)
         {
             _logger = logger;
             _settings = settings;
+            _debuggerAttacher = debuggerAttacher;
         }
 
 
@@ -223,7 +225,7 @@ namespace GoogleTestAdapter.TestAdapter
             bool isRunningInsideVisualStudio = !string.IsNullOrEmpty(runContext.SolutionDirectory);
             var reporter = new VsTestFrameworkReporter(frameworkHandle, isRunningInsideVisualStudio, _logger);
 
-            var debuggerAttacher = new MessageBasedDebuggerAttacher(_settings.DebuggingNamedPipeId, _logger);
+            var debuggerAttacher = _debuggerAttacher ?? new MessageBasedDebuggerAttacher(_settings.DebuggingNamedPipeId, _logger);
             var processExecutorFactory = new DebuggedProcessExecutorFactory(frameworkHandle, debuggerAttacher);
 
             lock (_lock)


### PR DESCRIPTION
Fix for #268 