### PR TITLE
Fixing incorrect logic when reducing to root test suite. Adding flags to allow for not reducing to root test suite.

### DIFF
--- a/GoogleTestAdapter/Core/GoogleTestExecutor.cs
+++ b/GoogleTestAdapter/Core/GoogleTestExecutor.cs
@@ -73,7 +73,7 @@ namespace GoogleTestAdapter
             }
             else
             {
-                _runner = new PreparingTestRunner(reporter, _logger, _settings, _schedulingAnalyzer);
+                _runner = new PreparingTestRunner(reporter, _logger, _settings, _schedulingAnalyzer, true);
                 if (_settings.ParallelTestExecution && isBeingDebugged)
                 {
                     _logger.DebugInfo(

--- a/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/ParallelTestRunner.cs
@@ -79,7 +79,7 @@ namespace GoogleTestAdapter.Runners
             int threadId = 0;
             foreach (List<TestCase> testcases in splittedTestCasesToRun)
             {
-                var runner = new PreparingTestRunner(threadId++, _frameworkReporter, _logger, _settings.Clone(), _schedulingAnalyzer);
+                var runner = new PreparingTestRunner(threadId++, _frameworkReporter, _logger, _settings.Clone(), _schedulingAnalyzer, false);
                 _testRunners.Add(runner);
 
                 var thread = new Thread(

--- a/GoogleTestAdapter/Core/Runners/PreparingTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/PreparingTestRunner.cs
@@ -25,7 +25,7 @@ namespace GoogleTestAdapter.Runners
         private readonly string _testDirectory;
 
 
-        public PreparingTestRunner(int threadId, ITestFrameworkReporter reporter, ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer)
+        public PreparingTestRunner(int threadId, ITestFrameworkReporter reporter, ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer, bool reduceToRootTestSuite)
         {
             _logger = logger;
             _settings = settings;
@@ -33,12 +33,12 @@ namespace GoogleTestAdapter.Runners
             _threadName = string.IsNullOrEmpty(threadName) ? "" : $"{threadName} ";
             _threadId = Math.Max(0, threadId);
             _testDirectory = Utils.GetTempDirectory();
-            _innerTestRunner = new SequentialTestRunner(_threadName, _threadId, _testDirectory, reporter, _logger, _settings, schedulingAnalyzer);
+            _innerTestRunner = new SequentialTestRunner(_threadName, _threadId, _testDirectory, reporter, _logger, _settings, schedulingAnalyzer, reduceToRootTestSuite);
         }
 
         public PreparingTestRunner(ITestFrameworkReporter reporter,
-            ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer)
-            : this(-1, reporter, logger, settings, schedulingAnalyzer){
+            ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer, bool reduceToRootTestSuite)
+            : this(-1, reporter, logger, settings, schedulingAnalyzer, reduceToRootTestSuite){
         }
 
 

--- a/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
+++ b/GoogleTestAdapter/Core/Runners/SequentialTestRunner.cs
@@ -28,10 +28,11 @@ namespace GoogleTestAdapter.Runners
         private readonly ILogger _logger;
         private readonly SettingsWrapper _settings;
         private readonly SchedulingAnalyzer _schedulingAnalyzer;
+        private readonly bool _reduceToRootTestSuite;
 
         private IProcessExecutor _processExecutor;
 
-        public SequentialTestRunner(string threadName, int threadId, string testDir, ITestFrameworkReporter reporter, ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer)
+        public SequentialTestRunner(string threadName, int threadId, string testDir, ITestFrameworkReporter reporter, ILogger logger, SettingsWrapper settings, SchedulingAnalyzer schedulingAnalyzer, bool reduceToRootTestSuite)
         {
             _threadName = threadName;
             _threadId = threadId;
@@ -40,6 +41,7 @@ namespace GoogleTestAdapter.Runners
             _logger = logger;
             _settings = settings;
             _schedulingAnalyzer = schedulingAnalyzer;
+            _reduceToRootTestSuite = reduceToRootTestSuite;
         }
 
 
@@ -90,7 +92,7 @@ namespace GoogleTestAdapter.Runners
             string resultXmlFile = Path.GetTempFileName();
             var serializer = new TestDurationSerializer();
 
-            var generator = new CommandLineGenerator(testCasesToRun, executable.Length, userParameters, resultXmlFile, _settings);
+            var generator = new CommandLineGenerator(testCasesToRun, executable.Length, userParameters, resultXmlFile, _settings, _reduceToRootTestSuite);
             foreach (CommandLineGenerator.Args arguments in generator.GetCommandLines())
             {
                 if (_canceled)


### PR DESCRIPTION
Potentially resolves csoltenborn/GoogleTestAdapter#330. This change fixed the problem I was facing, but it may not necessarily be correct for all cases. Will need to have a conversation about what the correct fix is. Making this PR to get that conversation started, and make the issue I created possibly make more sense.